### PR TITLE
Fix Docker dev dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM node:20-alpine
 WORKDIR /app
 COPY package.json tsconfig.json ./
-RUN npm install --production
+RUN npm install
 COPY src ./src
 RUN npm run build
+RUN npm prune --production
 CMD ["node", "dist/index.js"]


### PR DESCRIPTION
## Summary
- install dev dependencies so TypeScript can compile
- prune dev packages after build

## Testing
- `npm install`
- `npm run build`
- `docker build -t test-image .` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687d254167f88324aa3b6bb97a747503