### PR TITLE
Use guild name from env in ready event

### DIFF
--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -1,10 +1,16 @@
 import { Client, Events, ActivityType } from 'discord.js';
 
 export default function registerReady(client: Client) {
+  const guildName = process.env.WARMANE_GUILD_NAME || '';
+
   client.once(Events.ClientReady, async () => {
     console.log('Warmane Raid Bot is online!');
     if (client.user) {
-      client.user.setPresence({ activities: [{ name: 'Managing raids', type: ActivityType.Playing }], status: 'online' });
+      const presence = guildName ? `Managing ${guildName} raids` : 'Managing raids';
+      client.user.setPresence({
+        activities: [{ name: presence, type: ActivityType.Playing }],
+        status: 'online'
+      });
     }
   });
 }


### PR DESCRIPTION
## Summary
- read `WARMANE_GUILD_NAME` in `ready` event
- show more specific presence text when guild name is available

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687d2542ffbc8324a0fea343384d655e