### PR TITLE
Show registered characters after registration

### DIFF
--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -1,6 +1,7 @@
-import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
+import { SlashCommandBuilder, ChatInputCommandInteraction, EmbedBuilder } from 'discord.js';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { Command } from '../types';
+import { fetchCharacterSummary, getClassColor } from '../utils/warmane-api';
 
 const command: Command = {
   data: new SlashCommandBuilder()
@@ -20,11 +21,15 @@ const command: Command = {
     const character = interaction.options.getString('character', true);
     const altOf = interaction.options.getString('alt_of');
     const discordId = interaction.user.id;
+    const realm = process.env.WARMANE_REALM || 'Lordaeron';
 
-    if (!/^[A-Za-z\u00C0-\u017F]{2,12}$/.test(character)) {
-      await interaction.reply({ content: 'Invalid character name.', ephemeral: true });
-      return;
-    }
+      if (!/^[A-Za-z\u00C0-\u017F]{2,12}$/.test(character)) {
+        const embed = new EmbedBuilder()
+          .setColor(0xff0000)
+          .setDescription('Invalid character name.');
+        await interaction.reply({ embeds: [embed], ephemeral: true });
+        return;
+      }
 
     if (!altOf) {
       // Register main character
@@ -34,34 +39,87 @@ const command: Command = {
         .eq('discord_id', discordId)
         .maybeSingle();
 
-      if (existing) {
-        await interaction.reply({ content: 'You already registered a main character.', ephemeral: true });
-        return;
-      }
+        if (existing) {
+          const embed = new EmbedBuilder()
+            .setColor(0xff0000)
+            .setDescription('You already registered a main character.');
+          await interaction.reply({ embeds: [embed], ephemeral: true });
+          return;
+        }
 
-      await supabase.from('Players').insert({ discord_id: discordId, main_character: character, realm: process.env.WARMANE_REALM || 'Lordaeron' });
-      await interaction.reply({ content: `Registered ${character} as your main character!`, ephemeral: true });
-    } else {
-      // Register alt
-      const { data: player } = await supabase
-        .from('Players')
-        .select('id, main_character')
+        const { data: inserted, error } = await supabase
+          .from('Players')
+          .insert({ discord_id: discordId, main_character: character, realm })
+          .select('id, main_character')
+          .single();
+
+        if (!inserted || error) {
+          const embed = new EmbedBuilder()
+            .setColor(0xff0000)
+            .setDescription('Failed to register character.');
+          await interaction.reply({ embeds: [embed], ephemeral: true });
+          return;
+        }
+
+        const summary = await fetchCharacterSummary(character, realm).catch(() => null);
+        const color = summary ? getClassColor(summary.class) : 0x2f3136;
+
+        const { data: alts } = await supabase
+          .from('Alts')
+          .select('character_name')
+          .eq('player_id', inserted.id);
+
+        const charList = [inserted.main_character, ...(alts?.map(a => a.character_name) ?? [])];
+
+        const embed = new EmbedBuilder()
+          .setTitle('Registered Characters')
+          .setColor(color)
+          .setDescription(charList.join('\n'));
+
+        await interaction.reply({ embeds: [embed], ephemeral: true });
+      } else {
+        // Register alt
+        const { data: player } = await supabase
+          .from('Players')
+          .select('id, main_character')
         .eq('discord_id', discordId)
         .maybeSingle();
 
-      if (!player) {
-        await interaction.reply({ content: 'You must register a main character first.', ephemeral: true });
-        return;
-      }
-      if (player.main_character.toLowerCase() !== altOf.toLowerCase()) {
-        await interaction.reply({ content: 'Alt must belong to your registered main.', ephemeral: true });
-        return;
-      }
+        if (!player) {
+          const embed = new EmbedBuilder()
+            .setColor(0xff0000)
+            .setDescription('You must register a main character first.');
+          await interaction.reply({ embeds: [embed], ephemeral: true });
+          return;
+        }
+        if (player.main_character.toLowerCase() !== altOf.toLowerCase()) {
+          const embed = new EmbedBuilder()
+            .setColor(0xff0000)
+            .setDescription('Alt must belong to your registered main.');
+          await interaction.reply({ embeds: [embed], ephemeral: true });
+          return;
+        }
 
-      await supabase.from('Alts').insert({ player_id: player.id, character_name: character });
-      await interaction.reply({ content: `Registered ${character} as an alt of ${altOf}.`, ephemeral: true });
+        await supabase.from('Alts').insert({ player_id: player.id, character_name: character });
+
+        const summary = await fetchCharacterSummary(character, realm).catch(() => null);
+        const color = summary ? getClassColor(summary.class) : 0x2f3136;
+
+        const { data: alts } = await supabase
+          .from('Alts')
+          .select('character_name')
+          .eq('player_id', player.id);
+
+        const charList = [player.main_character, ...(alts?.map(a => a.character_name) ?? [])];
+
+        const embed = new EmbedBuilder()
+          .setTitle('Registered Characters')
+          .setColor(color)
+          .setDescription(charList.join('\n'));
+
+        await interaction.reply({ embeds: [embed], ephemeral: true });
+      }
     }
-  }
-};
+  };
 
 export default command;

--- a/src/utils/warmane-api.ts
+++ b/src/utils/warmane-api.ts
@@ -15,3 +15,20 @@ export async function fetchCharacterSummary(name: string, realm: string) {
   }
   return res.json();
 }
+
+export const CLASS_COLORS: Record<string, number> = {
+  'Death Knight': 0xc41f3b,
+  Druid: 0xff7d0a,
+  Hunter: 0xabd473,
+  Mage: 0x69ccf0,
+  Paladin: 0xf58cba,
+  Priest: 0xffffff,
+  Rogue: 0xfff569,
+  Shaman: 0x0070de,
+  Warlock: 0x9482c9,
+  Warrior: 0xc79c6e
+};
+
+export function getClassColor(className: string): number {
+  return CLASS_COLORS[className] ?? 0x2f3136;
+}


### PR DESCRIPTION
## Summary
- list all registered characters after registration
- add class color helpers

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687d25441fe88324b56617baaed175e5