### PR TITLE
Add scheduled guild role sync

### DIFF
--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -1,10 +1,30 @@
 import { Client, Events, ActivityType } from 'discord.js';
+import { syncGuildRoles } from '../utils/role-sync';
 
 export default function registerReady(client: Client) {
   client.once(Events.ClientReady, async () => {
     console.log('Warmane Raid Bot is online!');
     if (client.user) {
       client.user.setPresence({ activities: [{ name: 'Managing raids', type: ActivityType.Playing }], status: 'online' });
+    }
+
+    const guildId = process.env.GUILD_ID || '';
+    const guildName = process.env.WARMANE_GUILD_NAME || '';
+    const realm = process.env.WARMANE_REALM || 'Lordaeron';
+    const memberRoleId = process.env.MEMBER_ROLE_ID || '';
+    const interval = parseInt(process.env.SYNC_INTERVAL_MINUTES || '3', 10);
+
+    if (guildId && guildName && memberRoleId) {
+      try {
+        const guild = await client.guilds.fetch(guildId);
+        await guild.members.fetch();
+        setInterval(async () => {
+          await guild.members.fetch();
+          await syncGuildRoles(guild, guildName, realm, memberRoleId);
+        }, interval * 60 * 1000);
+      } catch (err) {
+        console.error('Failed to start role sync scheduler:', err);
+      }
     }
   });
 }

--- a/src/utils/role-sync.ts
+++ b/src/utils/role-sync.ts
@@ -1,10 +1,18 @@
-import { GuildMember } from 'discord.js';
+import { Guild, GuildMember } from 'discord.js';
 import { fetchGuildMembers } from './warmane-api';
 
-export async function syncMemberRoles(member: GuildMember, guildName: string, realm: string, memberRoleId: string) {
+export async function syncMemberRoles(
+  member: GuildMember,
+  guildName: string,
+  realm: string,
+  memberRoleId: string,
+  roster?: any
+) {
   try {
-    const roster = await fetchGuildMembers(guildName, realm);
-    const inGuild = roster.members.some((m: any) => m.name.toLowerCase() === member.displayName.toLowerCase());
+    const data = roster ?? (await fetchGuildMembers(guildName, realm));
+    const inGuild = data.members.some(
+      (m: any) => m.name.toLowerCase() === member.displayName.toLowerCase()
+    );
     if (inGuild) {
       if (!member.roles.cache.has(memberRoleId)) {
         await member.roles.add(memberRoleId);
@@ -12,7 +20,31 @@ export async function syncMemberRoles(member: GuildMember, guildName: string, re
     } else if (member.roles.cache.has(memberRoleId)) {
       await member.roles.remove(memberRoleId);
     }
-  } catch (err) {
-    console.error('Role sync error:', err);
+  } catch (err: any) {
+    if (err.status === 503) {
+      console.warn('Warmane API unavailable; skipping role sync.');
+    } else {
+      console.error('Role sync error:', err);
+    }
+  }
+}
+
+export async function syncGuildRoles(
+  guild: Guild,
+  guildName: string,
+  realm: string,
+  memberRoleId: string
+) {
+  try {
+    const roster = await fetchGuildMembers(guildName, realm);
+    for (const [, member] of guild.members.cache) {
+      await syncMemberRoles(member, guildName, realm, memberRoleId, roster);
+    }
+  } catch (err: any) {
+    if (err.status === 503) {
+      console.warn('Warmane API unavailable; skipping guild role sync.');
+    } else {
+      console.error('Guild role sync error:', err);
+    }
   }
 }

--- a/src/utils/warmane-api.ts
+++ b/src/utils/warmane-api.ts
@@ -1,7 +1,14 @@
 const BASE_URL = 'https://armory.warmane.com/api';
 
 export async function fetchGuildMembers(name: string, realm: string) {
-  const res = await fetch(`${BASE_URL}/guild/${encodeURIComponent(name)}/${encodeURIComponent(realm)}/members`);
+  const res = await fetch(
+    `${BASE_URL}/guild/${encodeURIComponent(name)}/${encodeURIComponent(realm)}/members`
+  );
+  if (res.status === 503) {
+    const err: any = new Error('Warmane API maintenance');
+    err.status = 503;
+    throw err;
+  }
   if (!res.ok) {
     throw new Error(`Warmane API error: ${res.status}`);
   }


### PR DESCRIPTION
## Summary
- fetchGuildMembers marks maintenance status for 503
- handle 503 errors in role sync utils and add guild-wide sync helper
- schedule periodic sync in ready event using SYNC_INTERVAL_MINUTES

## Testing
- `npm install`
- `npm run build`
- `node dist/index.js` *(fails: ERR_INVALID_URL due to missing env)*

------
https://chatgpt.com/codex/tasks/task_b_687d25465214832493510135cf37f547