### PR TITLE
Add command deployment script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
-    "dev": "ts-node src/index.ts"
+    "dev": "ts-node src/index.ts",
+    "deploy": "ts-node src/deploy-commands.ts"
   },
   "author": "",
   "license": "MIT",

--- a/src/deploy-commands.ts
+++ b/src/deploy-commands.ts
@@ -1,0 +1,30 @@
+import { REST, Routes } from 'discord.js';
+import dotenv from 'dotenv';
+import path from 'path';
+import fs from 'fs';
+
+dotenv.config();
+
+const commands = [] as any[];
+const commandsPath = path.join(__dirname, 'commands');
+const commandFiles = fs.readdirSync(commandsPath).filter(f => f.endsWith('.ts') || f.endsWith('.js'));
+
+for (const file of commandFiles) {
+  const command = require(path.join(commandsPath, file)).default;
+  commands.push(command.data.toJSON());
+}
+
+const rest = new REST({ version: '10' }).setToken(process.env.DISCORD_TOKEN!);
+
+(async () => {
+  try {
+    console.log(`Deploying ${commands.length} commands...`);
+    await rest.put(
+      Routes.applicationGuildCommands(process.env.CLIENT_ID!, process.env.GUILD_ID!),
+      { body: commands }
+    );
+    console.log('Commands deployed!');
+  } catch (error) {
+    console.error(error);
+  }
+})();

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -15,7 +15,6 @@ export default function registerReady(client: Client) {
     }
 
     const guildId = process.env.GUILD_ID || '';
-    const guildName = process.env.WARMANE_GUILD_NAME || '';
     const realm = process.env.WARMANE_REALM || 'Lordaeron';
     const memberRoleId = process.env.MEMBER_ROLE_ID || '';
     const interval = parseInt(process.env.SYNC_INTERVAL_MINUTES || '3', 10);


### PR DESCRIPTION
## Summary
- add new `deploy-commands.ts` script for registering slash commands
- wire `deploy` npm script
- fix variable redeclaration in `ready` event

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687d3a4b185c83248712cb960bbcb119