### PR TITLE
Add raid modal and signup buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.env
+package-lock.json

--- a/src/commands/raid.ts
+++ b/src/commands/raid.ts
@@ -1,41 +1,249 @@
-import { SlashCommandBuilder, ChatInputCommandInteraction, PermissionFlagsBits } from 'discord.js';
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  ModalBuilder,
+  TextInputBuilder,
+  TextInputStyle,
+  ActionRowBuilder,
+  PermissionFlagsBits,
+  EmbedBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  ModalSubmitInteraction,
+  ButtonInteraction,
+  TextChannel
+} from 'discord.js';
 import { SupabaseClient } from '@supabase/supabase-js';
-import { Command } from '../types';
+import { Command, Raid, RaidSignup } from '../types';
+import { buildRaidEmbed } from '../utils/embed-builder';
+
+const CREATE_MODAL_ID = 'raid-create-modal';
+const SIGNUP_ID = (raidId: string, role: string) => `raid-signup:${raidId}:${role}`;
 
 const command: Command = {
   data: new SlashCommandBuilder()
     .setName('raid')
     .setDescription('Raid management')
     .addSubcommand((sub) =>
-      sub.setName('create')
-        .setDescription('Create a raid event')
-        .addStringOption((opt) => opt.setName('title').setDescription('Raid title').setRequired(true))
-        .addStringOption((opt) => opt.setName('instance').setDescription('Instance, e.g., ICC25').setRequired(true))
-        .addStringOption((opt) => opt.setName('date').setDescription('YYYY-MM-DD HH:mm').setRequired(true))
-        .addIntegerOption((opt) => opt.setName('min_gs').setDescription('Minimum GS').setRequired(false))
+      sub.setName('create').setDescription('Create a raid event')
     )
-    .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild),
+    .addSubcommand((sub) =>
+      sub.setName('list').setDescription('List upcoming raids')
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('cancel')
+        .setDescription('Cancel a raid')
+        .addStringOption((opt) =>
+          opt.setName('id').setDescription('Raid ID').setRequired(true)
+        )
+    ),
   async execute(interaction: ChatInputCommandInteraction, supabase: SupabaseClient) {
-    if (!interaction.isChatInputCommand() || interaction.options.getSubcommand() !== 'create') {
-      await interaction.reply({ content: 'Unsupported subcommand', ephemeral: true });
-      return;
+    const sub = interaction.options.getSubcommand();
+
+    if (sub === 'create') {
+      if (!interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild)) {
+        await interaction.reply({ content: 'Missing permission.', ephemeral: true });
+        return;
+      }
+
+      const modal = new ModalBuilder()
+        .setCustomId(CREATE_MODAL_ID)
+        .setTitle('Create Raid')
+        .addComponents(
+          new ActionRowBuilder<TextInputBuilder>().addComponents(
+            new TextInputBuilder()
+              .setCustomId('title')
+              .setLabel('Title')
+              .setStyle(TextInputStyle.Short)
+              .setRequired(true)
+          ),
+          new ActionRowBuilder<TextInputBuilder>().addComponents(
+            new TextInputBuilder()
+              .setCustomId('instance')
+              .setLabel('Instance')
+              .setStyle(TextInputStyle.Short)
+              .setRequired(true)
+          ),
+          new ActionRowBuilder<TextInputBuilder>().addComponents(
+            new TextInputBuilder()
+              .setCustomId('date')
+              .setLabel('YYYY-MM-DD HH:mm')
+              .setStyle(TextInputStyle.Short)
+              .setRequired(true)
+          ),
+          new ActionRowBuilder<TextInputBuilder>().addComponents(
+            new TextInputBuilder()
+              .setCustomId('min_gs')
+              .setLabel('Minimum GS')
+              .setStyle(TextInputStyle.Short)
+              .setRequired(false)
+          )
+        );
+      await interaction.showModal(modal);
+    } else if (sub === 'list') {
+      const { data: raids } = await supabase
+        .from('Raids')
+        .select('id, title, instance, scheduled_date, status')
+        .order('scheduled_date', { ascending: true });
+
+      if (!raids || raids.length === 0) {
+        await interaction.reply({ content: 'No raids scheduled.', ephemeral: true });
+        return;
+      }
+
+      const embed = new EmbedBuilder().setTitle('Upcoming Raids');
+      for (const r of raids as Raid[]) {
+        embed.addFields({ name: r.id, value: `${r.instance} - ${r.scheduled_date}` });
+      }
+      await interaction.reply({ embeds: [embed], ephemeral: true });
+    } else if (sub === 'cancel') {
+      if (!interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild)) {
+        await interaction.reply({ content: 'Missing permission.', ephemeral: true });
+        return;
+      }
+
+      const id = interaction.options.getString('id', true);
+      const { data: raid } = await supabase
+        .from('Raids')
+        .update({ status: 'cancelled' })
+        .eq('id', id)
+        .select('signup_message_id')
+        .maybeSingle();
+
+      if (!raid) {
+        await interaction.reply({ content: 'Raid not found.', ephemeral: true });
+        return;
+      }
+
+      if (raid.signup_message_id && interaction.channel) {
+        try {
+          const chan = interaction.channel as TextChannel;
+          const msg = await chan.messages.fetch(raid.signup_message_id);
+          await msg.edit({ content: 'Raid cancelled.', components: [] });
+        } catch {}
+      }
+
+      await supabase.from('RaidSignups').delete().eq('raid_id', id);
+      await interaction.reply({ content: 'Raid cancelled.', ephemeral: true });
     }
+  }
+};
 
-    const title = interaction.options.getString('title', true);
-    const instance = interaction.options.getString('instance', true);
-    const date = interaction.options.getString('date', true);
-    const minGs = interaction.options.getInteger('min_gs') ?? 5500;
+export async function handleRaidCreateModal(
+  interaction: ModalSubmitInteraction,
+  supabase: SupabaseClient
+) {
+  const title = interaction.fields.getTextInputValue('title');
+  const instance = interaction.fields.getTextInputValue('instance');
+  const date = interaction.fields.getTextInputValue('date');
+  const minGsStr = interaction.fields.getTextInputValue('min_gs');
+  const minGs = minGsStr ? parseInt(minGsStr, 10) : 5500;
 
-    await supabase.from('Raids').insert({
+  let raidLeaderId: string | null = null;
+  const { data: player } = await supabase
+    .from('Players')
+    .select('id')
+    .eq('discord_id', interaction.user.id)
+    .maybeSingle();
+  if (player) raidLeaderId = player.id;
+
+  const { data: raid } = await supabase
+    .from('Raids')
+    .insert({
       title,
       instance,
       scheduled_date: date,
       min_gearscore: minGs,
-      raid_leader_id: null
-    });
+      raid_leader_id: raidLeaderId
+    })
+    .select('*')
+    .single();
 
-    await interaction.reply({ content: `Raid ${title} created for ${date}.`, ephemeral: true });
+  const buttons = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(SIGNUP_ID(raid.id, 'tank'))
+      .setLabel('Tank')
+      .setStyle(ButtonStyle.Primary),
+    new ButtonBuilder()
+      .setCustomId(SIGNUP_ID(raid.id, 'healer'))
+      .setLabel('Healer')
+      .setStyle(ButtonStyle.Success),
+    new ButtonBuilder()
+      .setCustomId(SIGNUP_ID(raid.id, 'dps'))
+      .setLabel('DPS')
+      .setStyle(ButtonStyle.Secondary)
+  );
+
+  const embed = buildRaidEmbed(raid as Raid);
+  const channel = interaction.channel as TextChannel;
+  const msg = await channel.send({ embeds: [embed], components: [buttons] });
+
+  await supabase.from('Raids').update({ signup_message_id: msg.id }).eq('id', raid.id);
+
+  await interaction.reply({ content: 'Raid created.', ephemeral: true });
+}
+
+export async function handleRaidSignupButton(
+  interaction: ButtonInteraction,
+  supabase: SupabaseClient
+) {
+  const [, raidId, role] = interaction.customId.split(':');
+
+  const { data: raid } = await supabase
+    .from('Raids')
+    .select('*')
+    .eq('id', raidId)
+    .maybeSingle();
+  if (!raid) {
+    await interaction.reply({ content: 'Raid not found.', ephemeral: true });
+    return;
   }
-};
+
+  const { data: player } = await supabase
+    .from('Players')
+    .select('main_character')
+    .eq('discord_id', interaction.user.id)
+    .maybeSingle();
+  if (!player) {
+    await interaction.reply({ content: 'Register a main character first.', ephemeral: true });
+    return;
+  }
+
+  const { data: gs } = await supabase
+    .from('GearScores')
+    .select('gear_score')
+    .eq('character_name', player.main_character)
+    .maybeSingle();
+
+  await supabase
+    .from('RaidSignups')
+    .delete()
+    .eq('raid_id', raidId)
+    .eq('character_name', player.main_character);
+
+  await supabase.from('RaidSignups').insert({
+    raid_id: raidId,
+    character_name: player.main_character,
+    role: role as 'tank' | 'healer' | 'dps',
+    gear_score: gs?.gear_score ?? null
+  });
+
+  const { data: signups } = await supabase
+    .from('RaidSignups')
+    .select('*')
+    .eq('raid_id', raidId);
+
+  const embed = buildRaidEmbed(raid as Raid, signups as RaidSignup[]);
+  if (raid.signup_message_id) {
+    try {
+      const chan = interaction.channel as TextChannel;
+      const msg = await chan.messages.fetch(raid.signup_message_id);
+      await msg.edit({ embeds: [embed] });
+    } catch {}
+  }
+
+  await interaction.reply({ content: 'Signed up!', ephemeral: true });
+}
 
 export default command;

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,18 +1,28 @@
 import { Client, Events } from 'discord.js';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { Command } from '../types';
+import { handleRaidCreateModal, handleRaidSignupButton } from '../commands/raid';
 
 export default function registerInteractionCreate(client: Client, commands: Map<string, Command>, supabase: SupabaseClient) {
   client.on(Events.InteractionCreate, async (interaction) => {
-    if (!interaction.isChatInputCommand()) return;
-    const command = commands.get(interaction.commandName);
-    if (!command) return;
-    try {
-      await command.execute(interaction, supabase);
-    } catch (err) {
-      console.error('Command error:', err);
-      if (!interaction.replied) {
-        await interaction.reply({ content: 'An error occurred.', ephemeral: true });
+    if (interaction.isChatInputCommand()) {
+      const command = commands.get(interaction.commandName);
+      if (!command) return;
+      try {
+        await command.execute(interaction, supabase);
+      } catch (err) {
+        console.error('Command error:', err);
+        if (!interaction.replied) {
+          await interaction.reply({ content: 'An error occurred.', ephemeral: true });
+        }
+      }
+    } else if (interaction.isModalSubmit()) {
+      if (interaction.customId === 'raid-create-modal') {
+        await handleRaidCreateModal(interaction, supabase);
+      }
+    } else if (interaction.isButton()) {
+      if (interaction.customId.startsWith('raid-signup:')) {
+        await handleRaidSignupButton(interaction, supabase);
       }
     }
   });

--- a/src/utils/embed-builder.ts
+++ b/src/utils/embed-builder.ts
@@ -1,12 +1,36 @@
 import { EmbedBuilder } from 'discord.js';
+import { Raid, RaidSignup } from '../types';
 
-export function buildRaidEmbed(title: string, instance: string, date: string, minGs: number) {
-  const embed = new EmbedBuilder()
-    .setTitle(title)
+export function buildRaidEmbed(raid: Raid, signups: RaidSignup[] = []) {
+  const tanks = signups
+    .filter((s) => s.role === 'tank')
+    .map((s) => `${s.character_name}${s.gear_score ? ` - ${s.gear_score} GS` : ''}`);
+  const healers = signups
+    .filter((s) => s.role === 'healer')
+    .map((s) => `${s.character_name}${s.gear_score ? ` - ${s.gear_score} GS` : ''}`);
+  const dps = signups
+    .filter((s) => s.role === 'dps')
+    .map((s) => `${s.character_name}${s.gear_score ? ` - ${s.gear_score} GS` : ''}`);
+
+  return new EmbedBuilder()
+    .setTitle(`${raid.instance} - ${raid.title}`)
     .addFields(
-      { name: 'Instance', value: instance, inline: true },
-      { name: 'Date', value: date, inline: true },
-      { name: 'Minimum GS', value: String(minGs), inline: true }
+      { name: 'Date', value: raid.scheduled_date, inline: false },
+      {
+        name: `Tanks (${tanks.length}/${raid.tank_slots})`,
+        value: tanks.join('\n') || '[open]',
+        inline: true
+      },
+      {
+        name: `Healers (${healers.length}/${raid.healer_slots})`,
+        value: healers.join('\n') || '[open]',
+        inline: true
+      },
+      {
+        name: `DPS (${dps.length}/${raid.dps_slots})`,
+        value: dps.join('\n') || '[open]',
+        inline: true
+      },
+      { name: 'Minimum GS', value: String(raid.min_gearscore), inline: false }
     );
-  return embed;
 }


### PR DESCRIPTION
## Summary
- implement raid creation modal and signup button handling
- show raid info embed and allow list/cancel
- update interaction handler for modals and buttons
- improve embed builder
- add .gitignore for build artifacts

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687d3c1ad8e0832480ee78a6e6f0a88f