### PR TITLE
Add button handler util

### DIFF
--- a/src/commands/raid.ts
+++ b/src/commands/raid.ts
@@ -10,11 +10,10 @@ import {
   ButtonBuilder,
   ButtonStyle,
   ModalSubmitInteraction,
-  ButtonInteraction,
   TextChannel
 } from 'discord.js';
 import { SupabaseClient } from '@supabase/supabase-js';
-import { Command, Raid, RaidSignup } from '../types';
+import { Command, Raid } from '../types';
 import { buildRaidEmbed } from '../utils/embed-builder';
 
 const CREATE_MODAL_ID = 'raid-create-modal';
@@ -184,66 +183,5 @@ export async function handleRaidCreateModal(
   await interaction.reply({ content: 'Raid created.', ephemeral: true });
 }
 
-export async function handleRaidSignupButton(
-  interaction: ButtonInteraction,
-  supabase: SupabaseClient
-) {
-  const [, raidId, role] = interaction.customId.split(':');
-
-  const { data: raid } = await supabase
-    .from('Raids')
-    .select('*')
-    .eq('id', raidId)
-    .maybeSingle();
-  if (!raid) {
-    await interaction.reply({ content: 'Raid not found.', ephemeral: true });
-    return;
-  }
-
-  const { data: player } = await supabase
-    .from('Players')
-    .select('main_character')
-    .eq('discord_id', interaction.user.id)
-    .maybeSingle();
-  if (!player) {
-    await interaction.reply({ content: 'Register a main character first.', ephemeral: true });
-    return;
-  }
-
-  const { data: gs } = await supabase
-    .from('GearScores')
-    .select('gear_score')
-    .eq('character_name', player.main_character)
-    .maybeSingle();
-
-  await supabase
-    .from('RaidSignups')
-    .delete()
-    .eq('raid_id', raidId)
-    .eq('character_name', player.main_character);
-
-  await supabase.from('RaidSignups').insert({
-    raid_id: raidId,
-    character_name: player.main_character,
-    role: role as 'tank' | 'healer' | 'dps',
-    gear_score: gs?.gear_score ?? null
-  });
-
-  const { data: signups } = await supabase
-    .from('RaidSignups')
-    .select('*')
-    .eq('raid_id', raidId);
-
-  const embed = buildRaidEmbed(raid as Raid, signups as RaidSignup[]);
-  if (raid.signup_message_id) {
-    try {
-      const chan = interaction.channel as TextChannel;
-      const msg = await chan.messages.fetch(raid.signup_message_id);
-      await msg.edit({ embeds: [embed] });
-    } catch {}
-  }
-
-  await interaction.reply({ content: 'Signed up!', ephemeral: true });
-}
 
 export default command;

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,7 +1,8 @@
 import { Client, Events } from 'discord.js';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { Command } from '../types';
-import { handleRaidCreateModal, handleRaidSignupButton } from '../commands/raid';
+import { handleRaidCreateModal } from '../commands/raid';
+import { handleRaidSignupButton } from '../utils/button-handlers';
 
 export default function registerInteractionCreate(client: Client, commands: Map<string, Command>, supabase: SupabaseClient) {
   client.on(Events.InteractionCreate, async (interaction) => {

--- a/src/utils/button-handlers.ts
+++ b/src/utils/button-handlers.ts
@@ -1,0 +1,66 @@
+import { ButtonInteraction, TextChannel } from 'discord.js';
+import { SupabaseClient } from '@supabase/supabase-js';
+import { Raid, RaidSignup } from '../types';
+import { buildRaidEmbed } from './embed-builder';
+
+export async function handleRaidSignupButton(
+  interaction: ButtonInteraction,
+  supabase: SupabaseClient
+) {
+  const [, raidId, role] = interaction.customId.split(':');
+
+  const { data: raid } = await supabase
+    .from('Raids')
+    .select('*')
+    .eq('id', raidId)
+    .maybeSingle();
+  if (!raid) {
+    await interaction.reply({ content: 'Raid not found.', ephemeral: true });
+    return;
+  }
+
+  const { data: player } = await supabase
+    .from('Players')
+    .select('main_character')
+    .eq('discord_id', interaction.user.id)
+    .maybeSingle();
+  if (!player) {
+    await interaction.reply({ content: 'Register a main character first.', ephemeral: true });
+    return;
+  }
+
+  const { data: gs } = await supabase
+    .from('GearScores')
+    .select('gear_score')
+    .eq('character_name', player.main_character)
+    .maybeSingle();
+
+  await supabase
+    .from('RaidSignups')
+    .delete()
+    .eq('raid_id', raidId)
+    .eq('character_name', player.main_character);
+
+  await supabase.from('RaidSignups').insert({
+    raid_id: raidId,
+    character_name: player.main_character,
+    role: role as 'tank' | 'healer' | 'dps',
+    gear_score: gs?.gear_score ?? null
+  });
+
+  const { data: signups } = await supabase
+    .from('RaidSignups')
+    .select('*')
+    .eq('raid_id', raidId);
+
+  const embed = buildRaidEmbed(raid as Raid, signups as RaidSignup[]);
+  if (raid.signup_message_id) {
+    try {
+      const chan = interaction.channel as TextChannel;
+      const msg = await chan.messages.fetch(raid.signup_message_id);
+      await msg.edit({ embeds: [embed] });
+    } catch {}
+  }
+
+  await interaction.reply({ content: 'Signed up!', ephemeral: true });
+}


### PR DESCRIPTION
## Summary
- move `handleRaidSignupButton` out of raid command
- create `src/utils/button-handlers.ts`
- update interaction handler to use new util

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687d3d7bf5d88324b849c4c9ab143f48