### PR TITLE
Rewrite raid embed builder

### DIFF
--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,6 +1,9 @@
 import { Client, Events } from 'discord.js';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { Command } from '../types';
+import { handleRaidCreateModal } from '../commands/raid';
+import { handleRaidSignupButton } from '../utils/button-handlers';
+import { handleGsSetSelectMenu } from '../commands/gs';
 
 export default function registerInteractionCreate(client: Client, commands: Map<string, Command>, supabase: SupabaseClient) {
   client.on(Events.InteractionCreate, async (interaction) => {

--- a/src/utils/embed-builder.ts
+++ b/src/utils/embed-builder.ts
@@ -1,36 +1,50 @@
 import { EmbedBuilder } from 'discord.js';
 import { Raid, RaidSignup } from '../types';
 
+/**
+ * Build a raid signup embed following the format outlined in AGENTS.md.
+ *
+ * Example structure:
+ * **ICC 25 - Saturday 8pm ST**
+ *
+ * 🛡️ **Tanks** (2/2)
+ * • Player - 6000 GS
+ * • [open]
+ *
+ * Footer:
+ * 📊 Average GS: 6000 | Min required: 5800
+ * 👥 Total: 1/25
+ */
 export function buildRaidEmbed(raid: Raid, signups: RaidSignup[] = []) {
-  const tanks = signups
-    .filter((s) => s.role === 'tank')
-    .map((s) => `${s.character_name}${s.gear_score ? ` - ${s.gear_score} GS` : ''}`);
-  const healers = signups
-    .filter((s) => s.role === 'healer')
-    .map((s) => `${s.character_name}${s.gear_score ? ` - ${s.gear_score} GS` : ''}`);
-  const dps = signups
-    .filter((s) => s.role === 'dps')
-    .map((s) => `${s.character_name}${s.gear_score ? ` - ${s.gear_score} GS` : ''}`);
+  const roleSection = (
+    emoji: string,
+    roleName: string,
+    role: 'tank' | 'healer' | 'dps',
+    max: number,
+  ) => {
+    const members = signups
+      .filter((s) => s.role === role)
+      .map((s) => `• ${s.character_name}${s.gear_score ? ` - ${s.gear_score} GS` : ''}`);
+    const open = max - members.length;
+    if (open > 0) {
+      members.push(`• [${open} ${open === 1 ? 'slot' : 'slots'} open]`);
+    }
+    const name = `${emoji} ${roleName} (${members.length - (open > 0 ? 1 : 0)}/${max})`;
+    const value = members.join('\n') || '• [open]';
+    return { name, value } as const;
+  };
+
+  const tankField = roleSection('🛡️', '**Tanks**', 'tank', raid.tank_slots);
+  const healerField = roleSection('💚', '**Healers**', 'healer', raid.healer_slots);
+  const dpsField = roleSection('⚔️', '**DPS**', 'dps', raid.dps_slots);
+
+  const gsValues = signups.map((s) => s.gear_score).filter((gs): gs is number => typeof gs === 'number');
+  const avgGs = gsValues.length > 0 ? Math.round(gsValues.reduce((a, b) => a + b, 0) / gsValues.length) : 0;
+  const totalSlots = raid.tank_slots + raid.healer_slots + raid.dps_slots;
+  const footer = `📊 Average GS: ${avgGs} | Min required: ${raid.min_gearscore}\n👥 Total: ${signups.length}/${totalSlots}`;
 
   return new EmbedBuilder()
-    .setTitle(`${raid.instance} - ${raid.title}`)
-    .addFields(
-      { name: 'Date', value: raid.scheduled_date, inline: false },
-      {
-        name: `Tanks (${tanks.length}/${raid.tank_slots})`,
-        value: tanks.join('\n') || '[open]',
-        inline: true
-      },
-      {
-        name: `Healers (${healers.length}/${raid.healer_slots})`,
-        value: healers.join('\n') || '[open]',
-        inline: true
-      },
-      {
-        name: `DPS (${dps.length}/${raid.dps_slots})`,
-        value: dps.join('\n') || '[open]',
-        inline: true
-      },
-      { name: 'Minimum GS', value: String(raid.min_gearscore), inline: false }
-    );
+    .setTitle(`${raid.instance} - ${raid.scheduled_date}`)
+    .addFields(tankField, healerField, dpsField)
+    .setFooter({ text: footer });
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,8 @@
     "rootDir": "src",
     "strict": true,
     "esModuleInterop": true,
+    "moduleResolution": "node",
+    "types": ["node"],
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true
   },


### PR DESCRIPTION
## Summary
- refactor embed-builder to match the raid embed example in `AGENTS.md`
- import modal/button handlers in `interactionCreate` so TypeScript compile passes
- update `tsconfig` with Node module resolution

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687d41f969f08324be370b5c5c95d798