### PR TITLE
Add modal-based raid creation

### DIFF
--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -2,7 +2,11 @@ import { Client, Events } from 'discord.js';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { Command } from '../types';
 import { handleRaidCreateModal } from '../commands/raid';
-import { handleRaidSignupButton } from '../utils/button-handlers';
+import {
+  handleRaidSignupButton,
+  handleRaidLeaveButton,
+  handleRaidRoleSelect,
+} from '../utils/button-handlers';
 import { handleGsSetSelectMenu } from '../commands/gs';
 
 export default function registerInteractionCreate(client: Client, commands: Map<string, Command>, supabase: SupabaseClient) {
@@ -25,9 +29,13 @@ export default function registerInteractionCreate(client: Client, commands: Map<
     } else if (interaction.isButton()) {
       if (interaction.customId.startsWith('raid-signup:')) {
         await handleRaidSignupButton(interaction, supabase);
+      } else if (interaction.customId.startsWith('raid-leave:')) {
+        await handleRaidLeaveButton(interaction, supabase);
       }
     } else if (interaction.isStringSelectMenu()) {
-      if (interaction.customId.startsWith('gs-set-select:')) {
+      if (interaction.customId.startsWith('raid-role-select:')) {
+        await handleRaidRoleSelect(interaction, supabase);
+      } else if (interaction.customId.startsWith('gs-set-select:')) {
         await handleGsSetSelectMenu(interaction, supabase);
       }
     }

--- a/src/utils/button-handlers.ts
+++ b/src/utils/button-handlers.ts
@@ -1,21 +1,45 @@
-import { ButtonInteraction, TextChannel } from 'discord.js';
+import {
+  ButtonInteraction,
+  TextChannel,
+  StringSelectMenuBuilder,
+  ActionRowBuilder,
+  StringSelectMenuInteraction,
+} from 'discord.js';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { Raid, RaidSignup } from '../types';
 import { buildRaidEmbed } from './embed-builder';
 
+const ROLE_SELECT_ID = (raidId: string) => `raid-role-select:${raidId}`;
+
 export async function handleRaidSignupButton(
   interaction: ButtonInteraction,
-  supabase: SupabaseClient
+  supabase: SupabaseClient,
 ) {
-  const [, raidId, role] = interaction.customId.split(':');
+  const [, raidId] = interaction.customId.split(':');
 
-  const { data: raid } = await supabase
-    .from('Raids')
-    .select('*')
-    .eq('id', raidId)
-    .maybeSingle();
+  const select = new StringSelectMenuBuilder()
+    .setCustomId(ROLE_SELECT_ID(raidId))
+    .setPlaceholder('Select role')
+    .addOptions(
+      { label: 'Tank', value: 'tank' },
+      { label: 'Healer', value: 'healer' },
+      { label: 'DPS', value: 'dps' },
+    );
+
+  const row = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select);
+  await interaction.reply({ content: 'Choose your role:', components: [row], ephemeral: true });
+}
+
+export async function handleRaidRoleSelect(
+  interaction: StringSelectMenuInteraction,
+  supabase: SupabaseClient,
+) {
+  const [, raidId] = interaction.customId.split(':');
+  const role = interaction.values[0] as 'tank' | 'healer' | 'dps';
+
+  const { data: raid } = await supabase.from('Raids').select('*').eq('id', raidId).maybeSingle();
   if (!raid) {
-    await interaction.reply({ content: 'Raid not found.', ephemeral: true });
+    await interaction.update({ content: 'Raid not found.', components: [] });
     return;
   }
 
@@ -25,7 +49,7 @@ export async function handleRaidSignupButton(
     .eq('discord_id', interaction.user.id)
     .maybeSingle();
   if (!player) {
-    await interaction.reply({ content: 'Register a main character first.', ephemeral: true });
+    await interaction.update({ content: 'Register a main character first.', components: [] });
     return;
   }
 
@@ -44,8 +68,8 @@ export async function handleRaidSignupButton(
   await supabase.from('RaidSignups').insert({
     raid_id: raidId,
     character_name: player.main_character,
-    role: role as 'tank' | 'healer' | 'dps',
-    gear_score: gs?.gear_score ?? null
+    role,
+    gear_score: gs?.gear_score ?? null,
   });
 
   const { data: signups } = await supabase
@@ -62,5 +86,50 @@ export async function handleRaidSignupButton(
     } catch {}
   }
 
-  await interaction.reply({ content: 'Signed up!', ephemeral: true });
+  await interaction.update({ content: `Signed up as ${role}!`, components: [] });
+}
+
+export async function handleRaidLeaveButton(
+  interaction: ButtonInteraction,
+  supabase: SupabaseClient,
+) {
+  const [, raidId] = interaction.customId.split(':');
+
+  const { data: raid } = await supabase.from('Raids').select('*').eq('id', raidId).maybeSingle();
+  if (!raid) {
+    await interaction.reply({ content: 'Raid not found.', ephemeral: true });
+    return;
+  }
+
+  const { data: player } = await supabase
+    .from('Players')
+    .select('main_character')
+    .eq('discord_id', interaction.user.id)
+    .maybeSingle();
+  if (!player) {
+    await interaction.reply({ content: 'Register a main character first.', ephemeral: true });
+    return;
+  }
+
+  await supabase
+    .from('RaidSignups')
+    .delete()
+    .eq('raid_id', raidId)
+    .eq('character_name', player.main_character);
+
+  const { data: signups } = await supabase
+    .from('RaidSignups')
+    .select('*')
+    .eq('raid_id', raidId);
+
+  const embed = buildRaidEmbed(raid as Raid, signups as RaidSignup[]);
+  if (raid.signup_message_id) {
+    try {
+      const chan = interaction.channel as TextChannel;
+      const msg = await chan.messages.fetch(raid.signup_message_id);
+      await msg.edit({ embeds: [embed] });
+    } catch {}
+  }
+
+  await interaction.reply({ content: 'You have left the raid.', ephemeral: true });
 }


### PR DESCRIPTION
## Summary
- update raid creation flow to use a modal
- store raid slots from modal inputs
- send signup and leave buttons on creation
- adjust button handlers for sign up, role selection and leaving

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687d52358e088324afa960692fd0e2c2