### PR TITLE
Add character select menu utility

### DIFF
--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -6,6 +6,7 @@ import {
   handleRaidSignupButton,
   handleRaidLeaveButton,
   handleRaidRoleSelect,
+  handleRaidCharacterSelect,
 } from '../utils/button-handlers';
 import { handleGsSetSelectMenu } from '../commands/gs';
 
@@ -35,6 +36,8 @@ export default function registerInteractionCreate(client: Client, commands: Map<
     } else if (interaction.isStringSelectMenu()) {
       if (interaction.customId.startsWith('raid-role-select:')) {
         await handleRaidRoleSelect(interaction, supabase);
+      } else if (interaction.customId.startsWith('raid-char-select:')) {
+        await handleRaidCharacterSelect(interaction, supabase);
       } else if (interaction.customId.startsWith('gs-set-select:')) {
         await handleGsSetSelectMenu(interaction, supabase);
       }

--- a/src/utils/character-select.ts
+++ b/src/utils/character-select.ts
@@ -1,0 +1,44 @@
+import { StringSelectMenuBuilder } from 'discord.js';
+import { SupabaseClient } from '@supabase/supabase-js';
+
+export interface CharacterSelectResult {
+  menu: StringSelectMenuBuilder;
+  characters: string[];
+}
+
+/**
+ * Build a character selection menu for a Discord user.
+ * Throws an error if the user has no registered characters.
+ */
+export async function buildCharacterSelectMenu(
+  supabase: SupabaseClient,
+  discordId: string,
+  customId: string,
+  placeholder = 'Select character'
+): Promise<CharacterSelectResult> {
+  const { data: player } = await supabase
+    .from('Players')
+    .select('id, main_character')
+    .eq('discord_id', discordId)
+    .maybeSingle();
+  if (!player) {
+    throw new Error('No characters registered');
+  }
+
+  const { data: alts } = await supabase
+    .from('Alts')
+    .select('character_name')
+    .eq('player_id', player.id);
+
+  const characters = [player.main_character, ...(alts?.map(a => a.character_name) ?? [])];
+  if (characters.length === 0) {
+    throw new Error('No characters registered');
+  }
+
+  const menu = new StringSelectMenuBuilder()
+    .setCustomId(customId)
+    .setPlaceholder(placeholder)
+    .addOptions(characters.map(c => ({ label: c, value: c })));
+
+  return { menu, characters };
+}


### PR DESCRIPTION
## Summary
- add new `buildCharacterSelectMenu` utility that returns a select menu with a user's characters
- use the new menu for `/gs set` when no character is specified
- allow raid signups to choose a character after selecting role
- handle raid character select menu interactions

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687d537620fc8324902b5aaee22c6fca