### PR TITLE
Add guild config utility with caching

### DIFF
--- a/src/commands/raid.ts
+++ b/src/commands/raid.ts
@@ -16,7 +16,7 @@ import {
 import { SupabaseClient } from '@supabase/supabase-js';
 import { Command, Raid } from '../types';
 import { buildRaidEmbed } from '../utils/embed-builder';
-import { getGuildConfig } from '../utils/guild-config';
+import { requireGuildConfig } from '../utils/guild-config';
 
 const CREATE_MODAL_ID = 'raid-create-modal';
 const SIGNUP_ID = (raidId: string) => `raid-signup:${raidId}`;
@@ -42,8 +42,8 @@ const command: Command = {
     ),
   async execute(interaction: ChatInputCommandInteraction, supabase: SupabaseClient) {
     const sub = interaction.options.getSubcommand();
-    const guildId = interaction.guildId ?? '';
-    const config = await getGuildConfig(guildId);
+    const config = await requireGuildConfig(interaction);
+    if (!config) return;
 
     if (sub === 'create') {
       if (!interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild)) {

--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -2,7 +2,7 @@ import { SlashCommandBuilder, ChatInputCommandInteraction, EmbedBuilder } from '
 import { SupabaseClient } from '@supabase/supabase-js';
 import { Command } from '../types';
 import { fetchCharacterSummary, getClassColor } from '../utils/warmane-api';
-import { getGuildConfig } from '../utils/guild-config';
+import { requireGuildConfig } from '../utils/guild-config';
 
 const command: Command = {
   data: new SlashCommandBuilder()
@@ -22,9 +22,10 @@ const command: Command = {
     const character = interaction.options.getString('character', true);
     const altOf = interaction.options.getString('alt_of');
     const discordId = interaction.user.id;
-    const guildId = interaction.guildId ?? '';
-    const config = await getGuildConfig(guildId);
-    const realm = config?.warmane_realm || 'Lordaeron';
+
+    const config = await requireGuildConfig(interaction);
+    if (!config) return;
+    const realm = config.warmane_realm;
 
       if (!/^[A-Za-z\u00C0-\u017F]{2,12}$/.test(character)) {
         const embed = new EmbedBuilder()

--- a/src/utils/guild-config.ts
+++ b/src/utils/guild-config.ts
@@ -1,12 +1,60 @@
+import { ChatInputCommandInteraction } from 'discord.js';
 import supabase from '../config/database';
 import { GuildConfig } from '../types';
 
-export async function getGuildConfig(guildId: string): Promise<GuildConfig | null> {
+interface CachedConfig {
+  config: GuildConfig | null;
+  expires: number;
+}
+
+const cache = new Map<string, CachedConfig>();
+
+export async function getGuildConfig(
+  guildId: string
+): Promise<GuildConfig | null> {
   if (!guildId) return null;
+
+  const cached = cache.get(guildId);
+  const now = Date.now();
+  if (cached && cached.expires > now) {
+    return cached.config;
+  }
+
   const { data } = await supabase
     .from('guild_configs')
     .select('*')
     .eq('discord_guild_id', guildId)
     .maybeSingle();
-  return data as GuildConfig | null;
+
+  const config = data && data.setup_complete ? (data as GuildConfig) : null;
+  cache.set(guildId, { config, expires: now + 5 * 60 * 1000 });
+  return config;
+}
+
+export async function requireGuildConfig(
+  interaction: ChatInputCommandInteraction
+): Promise<GuildConfig | null> {
+  const guildId = interaction.guildId ?? '';
+  const config = await getGuildConfig(guildId);
+  if (!config) {
+    await interaction.reply({
+      content: 'This server needs to be configured. An admin should run /setup',
+      ephemeral: true
+    });
+    return null;
+  }
+  return config;
+}
+
+export async function updateGuildConfig(
+  guildId: string,
+  updates: Partial<GuildConfig>
+): Promise<GuildConfig | null> {
+  if (!guildId) return null;
+  await supabase
+    .from('guild_configs')
+    .update(updates)
+    .eq('discord_guild_id', guildId);
+  cache.delete(guildId);
+  return getGuildConfig(guildId);
 }


### PR DESCRIPTION
## Summary
- implement caching and helpers in `guild-config.ts`
- use `requireGuildConfig` in `register` and `raid` commands

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687d5fe3b38c832496c54265315b72de