### PR TITLE
Use guild config for role sync and raids

### DIFF
--- a/src/events/guildMemberUpdate.ts
+++ b/src/events/guildMemberUpdate.ts
@@ -6,11 +6,6 @@ export default function registerGuildMemberUpdate(client: Client) {
   client.on(Events.GuildMemberUpdate, async (_, newMember) => {
     const config = await getGuildConfig(newMember.guild.id);
     if (!config || !config.warmane_guild_name || !config.member_role_id) return;
-    await syncMemberRoles(
-      newMember,
-      config.warmane_guild_name,
-      config.warmane_realm,
-      config.member_role_id
-    );
+    await syncMemberRoles(newMember);
   });
 }

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -26,12 +26,7 @@ export default function registerReady(client: Client) {
           await guild.members.fetch();
           setInterval(async () => {
             await guild.members.fetch();
-            await syncGuildRoles(
-              guild,
-              config.warmane_guild_name,
-              config.warmane_realm,
-              config.member_role_id as string
-            );
+            await syncGuildRoles(guild);
           }, SYNC_INTERVAL_MINUTES * 60 * 1000);
         } catch (err) {
           console.error('Failed to start role sync scheduler:', err);


### PR DESCRIPTION
## Summary
- rely on guild-specific config inside role sync utilities
- check officer role when creating raids and post signups in configured channel
- clean up event handlers for updated role sync

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687d60e6310483248d762165ba4dfe62