### PR TITLE
Add guild validation in setup

### DIFF
--- a/src/utils/warmane-api.ts
+++ b/src/utils/warmane-api.ts
@@ -1,8 +1,12 @@
 const BASE_URL = 'https://armory.warmane.com/api';
 
+function encodeGuildName(name: string): string {
+  return encodeURIComponent(name).replace(/%20/g, '+');
+}
+
 export async function fetchGuildMembers(name: string, realm: string) {
   const res = await fetch(
-    `${BASE_URL}/guild/${encodeURIComponent(name)}/${encodeURIComponent(realm)}/members`
+    `${BASE_URL}/guild/${encodeGuildName(name)}/${encodeURIComponent(realm)}/members`
   );
   if (res.status === 503) {
     const err: any = new Error('Warmane API maintenance');
@@ -19,6 +23,18 @@ export async function fetchCharacterSummary(name: string, realm: string) {
   const res = await fetch(`${BASE_URL}/character/${encodeURIComponent(name)}/${encodeURIComponent(realm)}/summary`);
   if (!res.ok) {
     throw new Error(`Warmane API error: ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function fetchGuildSummary(name: string, realm: string) {
+  const res = await fetch(
+    `${BASE_URL}/guild/${encodeGuildName(name)}/${encodeURIComponent(realm)}/summary`
+  );
+  if (!res.ok) {
+    const err: any = new Error(`Warmane API error: ${res.status}`);
+    err.status = res.status;
+    throw err;
   }
   return res.json();
 }


### PR DESCRIPTION
## Summary
- add `fetchGuildSummary` utility and use `+` encoding for guild names
- verify guild exists during setup wizard and show summary info

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687d6263db148324a31f7eb38d19a780