### PR TITLE
Enable multi-guild role syncing

### DIFF
--- a/src/events/guildCreate.ts
+++ b/src/events/guildCreate.ts
@@ -1,0 +1,24 @@
+import { Client, Events, Guild } from 'discord.js';
+import { getGuildConfig } from '../utils/guild-config';
+import { startRoleSyncTimer } from '../utils/role-sync';
+
+const SYNC_INTERVAL_MINUTES = 3;
+
+export default function registerGuildCreate(client: Client) {
+  client.on(Events.GuildCreate, async (guild: Guild) => {
+    try {
+      if (guild.systemChannel) {
+        await guild.systemChannel.send(
+          'Thanks for inviting me! Server admins should run `/setup` to configure the bot.'
+        );
+      }
+    } catch (err) {
+      console.error('Failed to send welcome message:', err);
+    }
+
+    const config = await getGuildConfig(guild.id);
+    if (config && config.warmane_guild_name && config.member_role_id) {
+      startRoleSyncTimer(client, guild.id, SYNC_INTERVAL_MINUTES);
+    }
+  });
+}

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -1,5 +1,5 @@
 import { Client, Events, ActivityType } from 'discord.js';
-import { syncGuildRoles } from '../utils/role-sync';
+import { startRoleSyncTimer } from '../utils/role-sync';
 import { getGuildConfig } from '../utils/guild-config';
 
 const SYNC_INTERVAL_MINUTES = 3;
@@ -24,10 +24,7 @@ export default function registerReady(client: Client) {
       if (config.warmane_guild_name && config.member_role_id) {
         try {
           await guild.members.fetch();
-          setInterval(async () => {
-            await guild.members.fetch();
-            await syncGuildRoles(guild);
-          }, SYNC_INTERVAL_MINUTES * 60 * 1000);
+          startRoleSyncTimer(client, guild.id, SYNC_INTERVAL_MINUTES);
         } catch (err) {
           console.error('Failed to start role sync scheduler:', err);
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { Command } from './types';
 import registerReady from './events/ready';
 import registerInteractionCreate from './events/interactionCreate';
 import registerGuildMemberUpdate from './events/guildMemberUpdate';
+import registerGuildCreate from './events/guildCreate';
 
 dotenv.config();
 
@@ -35,5 +36,6 @@ if (fs.existsSync(commandsPath)) {
 registerReady(client);
 registerInteractionCreate(client, commands, supabase);
 registerGuildMemberUpdate(client);
+registerGuildCreate(client);
 
 client.login(DISCORD_TOKEN);


### PR DESCRIPTION
## Summary
- track role sync timers per guild
- initialize role sync for each configured guild on ready
- perform initial sync when the bot joins a configured server
- expose role sync utilities and timer management

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687d64452d3483249adb76b8fb99a010