### PR TITLE
Fix command option order

### DIFF
--- a/src/commands/gs.ts
+++ b/src/commands/gs.ts
@@ -28,14 +28,14 @@ const command: Command = {
       sub
         .setName('set')
         .setDescription('Set a character GearScore')
-        .addStringOption((opt) =>
-          opt.setName('character').setDescription('Character name').setRequired(false)
-        )
         .addIntegerOption((opt) =>
           opt
             .setName('score')
             .setDescription('GearScore (3000-7000)')
             .setRequired(true)
+        )
+        .addStringOption((opt) =>
+          opt.setName('character').setDescription('Character name').setRequired(false)
         )
     )
     .addSubcommand((sub) =>


### PR DESCRIPTION
## Summary
- reorder `gs` command options so required ones come first

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687d6d1347708324b804376d0093ffc0