### PR TITLE
Remove admin-only restriction on setup command

### DIFF
--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -57,8 +57,7 @@ const command: Command = {
     )
     .addSubcommand((sub) =>
       sub.setName('status').setDescription('Show current configuration')
-    )
-    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
+    ),
   async execute(interaction: ChatInputCommandInteraction, supabase: SupabaseClient) {
     if (!interaction.guild) {
       await interaction.reply({ content: 'This command can only be used in a server.', ephemeral: true });


### PR DESCRIPTION
## Summary
- allow any user to run `/setup` by removing the default permission

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687d73f48fb08324b2fa0d7d21e8687b