### PR TITLE
Add missing DM intents

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,12 @@ if (!DISCORD_TOKEN) {
 }
 
 const client = new Client({
-  intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMembers]
+  intents: [
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildMembers,
+    GatewayIntentBits.DirectMessages,
+    GatewayIntentBits.MessageContent
+  ]
 });
 
 const commands = new Collection<string, Command>();


### PR DESCRIPTION
## Summary
- allow the bot to read direct messages and message content by setting DirectMessages and MessageContent intents

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687d78186a788324b04e496aafdcc0a1