### PR TITLE
Fix setup cache clearing

### DIFF
--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -12,6 +12,7 @@ import {
 import { SupabaseClient } from '@supabase/supabase-js';
 import { Command } from '../types';
 import { fetchGuildSummary } from '../utils/warmane-api';
+import { cache } from '../utils/guild-config';
 
 const REALMS = ['Lordaeron', 'Icecrown', 'Frostmourne', 'Onyxia'];
 
@@ -201,6 +202,7 @@ const command: Command = {
         setup_complete: true,
         setup_by_user_id: interaction.user.id
       });
+      cache.delete(guildId);
 
       const embed = new EmbedBuilder()
         .setTitle('Setup Complete')

--- a/src/utils/guild-config.ts
+++ b/src/utils/guild-config.ts
@@ -7,7 +7,7 @@ interface CachedConfig {
   expires: number;
 }
 
-const cache = new Map<string, CachedConfig>();
+export const cache = new Map<string, CachedConfig>();
 
 export async function getGuildConfig(
   guildId: string


### PR DESCRIPTION
## Summary
- export cache map from `guild-config`
- clear setup cache after saving guild config

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687d7c306878832498419f5a81932946