### PR TITLE
Add automatic GearScore calculation on registration

### DIFF
--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -1,8 +1,18 @@
-import { SlashCommandBuilder, ChatInputCommandInteraction, EmbedBuilder } from 'discord.js';
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  ActionRowBuilder,
+  ComponentType,
+} from 'discord.js';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { Command } from '../types';
 import { fetchCharacterSummary, getClassColor } from '../utils/warmane-api';
 import { requireGuildConfig } from '../utils/guild-config';
+import { gearScoreCalculator } from '../utils/gearscore-calculator';
+import { updateGearScore } from '../utils/database';
 
 const command: Command = {
   data: new SlashCommandBuilder()
@@ -29,27 +39,63 @@ const command: Command = {
     if (!config) return;
     const realm = config.warmane_realm;
 
-      if (!/^[A-Za-z\u00C0-\u017F]{2,12}$/.test(character)) {
-        const embed = new EmbedBuilder()
-          .setColor(0xff0000)
-          .setDescription('Invalid character name.');
-        await interaction.reply({ embeds: [embed], ephemeral: true });
+    if (!/^[A-Za-z\u00C0-\u017F]{2,12}$/.test(character)) {
+      const embed = new EmbedBuilder()
+        .setColor(0xff0000)
+        .setDescription('Invalid character name.');
+      await interaction.reply({ embeds: [embed], ephemeral: true });
+      return;
+    }
+
+    let summary: any;
+    try {
+      summary = await fetchCharacterSummary(character, realm);
+    } catch {
+      await interaction.reply({ content: 'Character not found on Warmane.', ephemeral: true });
+      return;
+    }
+
+    const gearScore = gearScoreCalculator.calculate(summary.equipment ?? []);
+    const color = getClassColor(summary.class);
+
+    const confirmEmbed = new EmbedBuilder()
+      .setTitle('Confirm Registration')
+      .setColor(color)
+      .addFields(
+        { name: 'Name', value: summary.name, inline: true },
+        { name: 'Class', value: summary.class, inline: true },
+        { name: 'Guild', value: summary.guild ?? 'None', inline: true },
+        { name: 'GearScore', value: gearScore.toString(), inline: true }
+      );
+
+    const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder().setCustomId('register-confirm').setLabel('Confirm').setStyle(ButtonStyle.Success),
+      new ButtonBuilder().setCustomId('register-cancel').setLabel('Cancel').setStyle(ButtonStyle.Secondary)
+    );
+
+    const msg = await interaction.reply({ embeds: [confirmEmbed], components: [row], ephemeral: true, fetchReply: true });
+
+    try {
+      const button = await msg.awaitMessageComponent({
+        componentType: ComponentType.Button,
+        time: 30_000,
+        filter: (i) => i.user.id === interaction.user.id,
+      });
+
+      if (button.customId === 'register-cancel') {
+        await button.update({ content: 'Registration cancelled.', components: [], embeds: [] });
         return;
       }
 
-    if (!altOf) {
-      // Register main character
-      const { data: existing } = await supabase
-        .from('Players')
-        .select('*')
-        .eq('discord_id', discordId)
-        .maybeSingle();
+      if (!altOf) {
+        const { data: existing } = await supabase
+          .from('Players')
+          .select('*')
+          .eq('discord_id', discordId)
+          .maybeSingle();
 
         if (existing) {
-          const embed = new EmbedBuilder()
-            .setColor(0xff0000)
-            .setDescription('You already registered a main character.');
-          await interaction.reply({ embeds: [embed], ephemeral: true });
+          await button.update({ content: 'You already registered a main character.', components: [] });
           return;
         }
 
@@ -60,72 +106,63 @@ const command: Command = {
           .single();
 
         if (!inserted || error) {
-          const embed = new EmbedBuilder()
-            .setColor(0xff0000)
-            .setDescription('Failed to register character.');
-          await interaction.reply({ embeds: [embed], ephemeral: true });
+          await button.update({ content: 'Failed to register character.', components: [] });
           return;
         }
 
-        const summary = await fetchCharacterSummary(character, realm).catch(() => null);
-        const color = summary ? getClassColor(summary.class) : 0x2f3136;
+        await updateGearScore(supabase, character, gearScore, inserted.id);
 
         const { data: alts } = await supabase
           .from('Alts')
           .select('character_name')
           .eq('player_id', inserted.id);
 
-        const charList = [inserted.main_character, ...(alts?.map(a => a.character_name) ?? [])];
+        const charList = [inserted.main_character, ...(alts?.map((a) => a.character_name) ?? [])];
 
         const embed = new EmbedBuilder()
           .setTitle('Registered Characters')
           .setColor(color)
           .setDescription(charList.join('\n'));
 
-        await interaction.reply({ embeds: [embed], ephemeral: true });
+        await button.update({ embeds: [embed], components: [] });
       } else {
-        // Register alt
         const { data: player } = await supabase
           .from('Players')
           .select('id, main_character')
-        .eq('discord_id', discordId)
-        .maybeSingle();
+          .eq('discord_id', discordId)
+          .maybeSingle();
 
         if (!player) {
-          const embed = new EmbedBuilder()
-            .setColor(0xff0000)
-            .setDescription('You must register a main character first.');
-          await interaction.reply({ embeds: [embed], ephemeral: true });
+          await button.update({ content: 'You must register a main character first.', components: [] });
           return;
         }
+
         if (player.main_character.toLowerCase() !== altOf.toLowerCase()) {
-          const embed = new EmbedBuilder()
-            .setColor(0xff0000)
-            .setDescription('Alt must belong to your registered main.');
-          await interaction.reply({ embeds: [embed], ephemeral: true });
+          await button.update({ content: 'Alt must belong to your registered main.', components: [] });
           return;
         }
 
         await supabase.from('Alts').insert({ player_id: player.id, character_name: character });
-
-        const summary = await fetchCharacterSummary(character, realm).catch(() => null);
-        const color = summary ? getClassColor(summary.class) : 0x2f3136;
+        await updateGearScore(supabase, character, gearScore, player.id);
 
         const { data: alts } = await supabase
           .from('Alts')
           .select('character_name')
           .eq('player_id', player.id);
 
-        const charList = [player.main_character, ...(alts?.map(a => a.character_name) ?? [])];
+        const charList = [player.main_character, ...(alts?.map((a) => a.character_name) ?? [])];
 
         const embed = new EmbedBuilder()
           .setTitle('Registered Characters')
           .setColor(color)
           .setDescription(charList.join('\n'));
 
-        await interaction.reply({ embeds: [embed], ephemeral: true });
+        await button.update({ embeds: [embed], components: [] });
       }
+    } catch {
+      await interaction.editReply({ content: 'Registration timed out.', components: [], embeds: [] });
     }
+  }
   };
 
 export default command;

--- a/src/utils/gearscore-calculator.ts
+++ b/src/utils/gearscore-calculator.ts
@@ -1,0 +1,56 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { GEAR_SLOT_WEIGHTS } from './gearscore-weights';
+
+interface Item {
+  itemId: number;
+  itemLevel: number;
+  slot: string;
+}
+
+class GearScoreCalculator {
+  private items: Map<number, Item> = new Map();
+
+  constructor() {
+    this.loadItemData();
+  }
+
+  private loadItemData() {
+    try {
+      // Assumes equippable_items.json is in the project's root directory
+      const jsonPath = path.join(__dirname, '../../items.min.json');
+      const fileContent = fs.readFileSync(jsonPath, 'utf-8');
+      const itemList: Item[] = JSON.parse(fileContent);
+
+      for (const item of itemList) {
+        this.items.set(item.itemId, item);
+      }
+      console.log(`Loaded ${this.items.size} items into the GearScore calculator.`);
+    } catch (error) {
+      console.error('Failed to load or parse equippable_items.json:', error);
+    }
+  }
+
+  // The 'equippedItems' array comes from the Warmane API response
+  public calculate(equippedItems: { name: string; itemID: string }[]): number {
+    let totalScore = 0;
+    if (!equippedItems) return 0;
+
+    for (const equippedItem of equippedItems) {
+      const itemId = parseInt(equippedItem.itemID, 10);
+      const itemData = this.items.get(itemId);
+
+      if (itemData) {
+        const slot = itemData.slot;
+        const weight = GEAR_SLOT_WEIGHTS[slot] || 0;
+        if (weight > 0) {
+          totalScore += itemData.itemLevel * weight;
+        }
+      }
+    }
+    return Math.round(totalScore);
+  }
+}
+
+// Export a singleton instance so the data is only loaded once
+export const gearScoreCalculator = new GearScoreCalculator();

--- a/src/utils/gearscore-weights.ts
+++ b/src/utils/gearscore-weights.ts
@@ -1,0 +1,23 @@
+export const GEAR_SLOT_WEIGHTS: { [key: string]: number } = {
+  Head: 1.35,
+  Shoulder: 1.125,
+  Chest: 1.35,
+  Waist: 1.0,
+  Legs: 1.35,
+  Feet: 1.0,
+  Wrist: 0.75,
+  Hands: 1.0,
+  Neck: 1.0,
+  Back: 0.75,
+  Finger: 0.75,
+  Trinket: 1.25,
+  Weapon: 2.375,
+  WeaponMainHand: 1.5,
+  WeaponOffHand: 0.75,
+  Shield: 1.0,
+  Ranged: 0.75,
+  Relic: 0.75,
+  "Two-Hand": 2.375,
+  "Main Hand": 1.5,
+  "Off Hand": 0.75
+};


### PR DESCRIPTION
## Summary
- add gear slot weight table
- implement GearScore calculator that loads item database
- integrate calculator into `/register`
- prompt users to confirm registration with GearScore

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687d8e8166d48324b1db3813457ffe1d