### PR TITLE
Implement character management features

### DIFF
--- a/src/commands/character.ts
+++ b/src/commands/character.ts
@@ -1,0 +1,98 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  ActionRowBuilder,
+  StringSelectMenuBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  ComponentType
+} from 'discord.js';
+import { SupabaseClient } from '@supabase/supabase-js';
+import { Command } from '../types';
+
+const DELETE_SELECT_ID = 'character-delete-select';
+const DELETE_CONFIRM_ID = 'character-delete-confirm';
+
+const command: Command = {
+  data: new SlashCommandBuilder()
+    .setName('character')
+    .setDescription('Manage your characters')
+    .addSubcommand((sub) => sub.setName('view').setDescription('View your characters'))
+    .addSubcommand((sub) => sub.setName('delete').setDescription('Delete a character')),
+  async execute(interaction: ChatInputCommandInteraction, supabase: SupabaseClient) {
+    const sub = interaction.options.getSubcommand();
+    const discordId = interaction.user.id;
+
+    if (sub === 'view') {
+      const { data: chars } = await supabase
+        .from('Players')
+        .select('id, main_character, realm')
+        .eq('discord_id', discordId);
+
+      if (!chars || chars.length === 0) {
+        await interaction.reply({ content: 'You have no registered characters.', ephemeral: true });
+        return;
+      }
+
+      const list = chars.map(c => `* **${c.main_character}** - *${c.realm}*`).join('\n');
+      await interaction.reply({ content: `Your Registered Characters:\n${list}`, ephemeral: true });
+    } else if (sub === 'delete') {
+      const { data: chars } = await supabase
+        .from('Players')
+        .select('id, main_character, realm')
+        .eq('discord_id', discordId);
+
+      if (!chars || chars.length === 0) {
+        await interaction.reply({ content: 'You have no registered characters.', ephemeral: true });
+        return;
+      }
+
+      const menu = new StringSelectMenuBuilder()
+        .setCustomId(DELETE_SELECT_ID)
+        .setPlaceholder('Select character')
+        .addOptions(chars.map(c => ({
+          label: `${c.main_character} (${c.realm})`,
+          value: c.id
+        })));
+
+      const row = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu);
+      const msg = await interaction.reply({ content: 'Choose a character to delete:', components: [row], ephemeral: true, fetchReply: true });
+
+      try {
+        const select = await msg.awaitMessageComponent({
+          componentType: ComponentType.StringSelect,
+          time: 30_000,
+          filter: i => i.user.id === discordId
+        });
+
+        const charId = select.values[0];
+        const chosen = chars.find(c => c.id === charId);
+        if (!chosen) {
+          await select.update({ content: 'Invalid selection.', components: [] });
+          return;
+        }
+
+        const confirmRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
+          new ButtonBuilder().setCustomId(DELETE_CONFIRM_ID).setLabel('Confirm').setStyle(ButtonStyle.Danger)
+        );
+        const confirmMsg = await select.update({ content: `Delete ${chosen.main_character} on ${chosen.realm}?`, components: [confirmRow] });
+
+        const btn = await confirmMsg.awaitMessageComponent({
+          componentType: ComponentType.Button,
+          time: 30_000,
+          filter: i => i.user.id === discordId
+        });
+
+        if (btn.customId === DELETE_CONFIRM_ID) {
+          await supabase.from('Players').delete().eq('id', charId);
+          await btn.update({ content: `${chosen.main_character} has been deleted.`, components: [] });
+        }
+      } catch {
+        await interaction.editReply({ content: 'Action timed out.', components: [] });
+      }
+    }
+  }
+};
+
+export default command;
+

--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -1,52 +1,50 @@
 import {
   SlashCommandBuilder,
-  ChatInputCommandInteraction,
-  EmbedBuilder,
-  ButtonBuilder,
-  ButtonStyle,
-  ActionRowBuilder,
-  ComponentType,
+  ChatInputCommandInteraction
 } from 'discord.js';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { Command } from '../types';
-import { fetchCharacterSummary, getClassColor } from '../utils/warmane-api';
 import { requireGuildConfig } from '../utils/guild-config';
+import { fetchCharacterSummary } from '../utils/warmane-api';
 import { gearScoreCalculator } from '../utils/gearscore-calculator';
 import { updateGearScore } from '../utils/database';
 
 const command: Command = {
   data: new SlashCommandBuilder()
     .setName('register')
-    .setDescription('Register your character')
+    .setDescription('Register a character')
     .addStringOption((opt) =>
-      opt.setName('character')
-        .setDescription('Character name (must be spelled exactly as in-game)')
+      opt
+        .setName('character')
+        .setDescription('Character name (exact in-game spelling)')
         .setRequired(true)
-    )
-    .addStringOption((opt) =>
-      opt.setName('alt_of')
-        .setDescription(
-          'Main character if registering an alt (must be spelled exactly as in-game)'
-        )
-        .setRequired(false)
     ),
   async execute(interaction: ChatInputCommandInteraction, supabase: SupabaseClient) {
     const character = interaction.options.getString('character', true);
-    const altOf = interaction.options.getString('alt_of');
     const discordId = interaction.user.id;
 
     const config = await requireGuildConfig(interaction);
     if (!config) return;
     const realm = config.warmane_realm;
 
-    if (!/^[A-Za-z\u00C0-\u017F]{2,12}$/.test(character)) {
-      const embed = new EmbedBuilder()
-        .setColor(0xff0000)
-        .setDescription('Invalid character name.');
-      await interaction.reply({ embeds: [embed], ephemeral: true });
+    // Prevent duplicate registration of the same character for this user
+    const { data: existing } = await supabase
+      .from('Players')
+      .select('id')
+      .eq('discord_id', discordId)
+      .eq('main_character', character)
+      .eq('realm', realm)
+      .maybeSingle();
+
+    if (existing) {
+      await interaction.reply({
+        content: `You already registered **${character}** on **${realm}**.`,
+        ephemeral: true
+      });
       return;
     }
 
+    // Fetch character data from Warmane API
     let summary: any;
     try {
       summary = await fetchCharacterSummary(character, realm);
@@ -56,113 +54,27 @@ const command: Command = {
     }
 
     const gearScore = gearScoreCalculator.calculate(summary.equipment ?? []);
-    const color = getClassColor(summary.class);
 
-    const confirmEmbed = new EmbedBuilder()
-      .setTitle('Confirm Registration')
-      .setColor(color)
-      .addFields(
-        { name: 'Name', value: summary.name, inline: true },
-        { name: 'Class', value: summary.class, inline: true },
-        { name: 'Guild', value: summary.guild ?? 'None', inline: true },
-        { name: 'GearScore', value: gearScore.toString(), inline: true }
-      );
+    const { data: inserted, error } = await supabase
+      .from('Players')
+      .insert({ discord_id: discordId, main_character: character, realm })
+      .select('id')
+      .single();
 
-    const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
-      new ButtonBuilder().setCustomId('register-confirm').setLabel('Confirm').setStyle(ButtonStyle.Success),
-      new ButtonBuilder().setCustomId('register-cancel').setLabel('Cancel').setStyle(ButtonStyle.Secondary)
-    );
-
-    const msg = await interaction.reply({ embeds: [confirmEmbed], components: [row], ephemeral: true, fetchReply: true });
-
-    try {
-      const button = await msg.awaitMessageComponent({
-        componentType: ComponentType.Button,
-        time: 30_000,
-        filter: (i) => i.user.id === interaction.user.id,
-      });
-
-      if (button.customId === 'register-cancel') {
-        await button.update({ content: 'Registration cancelled.', components: [], embeds: [] });
-        return;
-      }
-
-      if (!altOf) {
-        const { data: existing } = await supabase
-          .from('Players')
-          .select('*')
-          .eq('discord_id', discordId)
-          .maybeSingle();
-
-        if (existing) {
-          await button.update({ content: 'You already registered a main character.', components: [] });
-          return;
-        }
-
-        const { data: inserted, error } = await supabase
-          .from('Players')
-          .insert({ discord_id: discordId, main_character: character, realm })
-          .select('id, main_character')
-          .single();
-
-        if (!inserted || error) {
-          await button.update({ content: 'Failed to register character.', components: [] });
-          return;
-        }
-
-        await updateGearScore(supabase, character, gearScore, inserted.id);
-
-        const { data: alts } = await supabase
-          .from('Alts')
-          .select('character_name')
-          .eq('player_id', inserted.id);
-
-        const charList = [inserted.main_character, ...(alts?.map((a) => a.character_name) ?? [])];
-
-        const embed = new EmbedBuilder()
-          .setTitle('Registered Characters')
-          .setColor(color)
-          .setDescription(charList.join('\n'));
-
-        await button.update({ embeds: [embed], components: [] });
-      } else {
-        const { data: player } = await supabase
-          .from('Players')
-          .select('id, main_character')
-          .eq('discord_id', discordId)
-          .maybeSingle();
-
-        if (!player) {
-          await button.update({ content: 'You must register a main character first.', components: [] });
-          return;
-        }
-
-        if (player.main_character.toLowerCase() !== altOf.toLowerCase()) {
-          await button.update({ content: 'Alt must belong to your registered main.', components: [] });
-          return;
-        }
-
-        await supabase.from('Alts').insert({ player_id: player.id, character_name: character });
-        await updateGearScore(supabase, character, gearScore, player.id);
-
-        const { data: alts } = await supabase
-          .from('Alts')
-          .select('character_name')
-          .eq('player_id', player.id);
-
-        const charList = [player.main_character, ...(alts?.map((a) => a.character_name) ?? [])];
-
-        const embed = new EmbedBuilder()
-          .setTitle('Registered Characters')
-          .setColor(color)
-          .setDescription(charList.join('\n'));
-
-        await button.update({ embeds: [embed], components: [] });
-      }
-    } catch {
-      await interaction.editReply({ content: 'Registration timed out.', components: [], embeds: [] });
+    if (!inserted || error) {
+      await interaction.reply({ content: 'Failed to register character.', ephemeral: true });
+      return;
     }
+
+    await updateGearScore(supabase, character, gearScore, inserted.id);
+
+    const armoryUrl = `https://armory.warmane.com/character/${encodeURIComponent(character)}/${encodeURIComponent(realm)}`;
+
+    await interaction.reply({
+      content: `Character [${character}](${armoryUrl}) on ${realm} has been registered successfully! Your GearScore is ${gearScore}.`,
+      ephemeral: true
+    });
   }
-  };
+};
 
 export default command;


### PR DESCRIPTION
## Summary
- allow multiple characters to be registered and fetch gearscore automatically
- add `/character` command to view or delete characters

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687d928e0d4083249fde90817ae6e8ab