### PR TITLE
Implement smart guild sync task

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,12 @@
         "@supabase/supabase-js": "^2.39.3",
         "discord.js": "^14.11.0",
         "dotenv": "^16.3.1",
+        "node-cron": "^3.0.3",
         "node-fetch": "^2.6.7"
       },
       "devDependencies": {
         "@types/node": "^24.0.15",
+        "@types/node-cron": "^3.0.11",
         "@types/node-fetch": "^2.6.12",
         "ts-node": "^10.9.1",
         "typescript": "^5.3.3"
@@ -333,6 +335,13 @@
       "dependencies": {
         "undici-types": "~7.8.0"
       }
+    },
+    "node_modules/@types/node-cron": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/node-cron/-/node-cron-3.0.11.tgz",
+      "integrity": "sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.12",
@@ -776,6 +785,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "license": "ISC",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -886,6 +907,15 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
       "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -15,10 +15,12 @@
     "@supabase/supabase-js": "^2.39.3",
     "discord.js": "^14.11.0",
     "dotenv": "^16.3.1",
+    "node-cron": "^3.0.3",
     "node-fetch": "^2.6.7"
   },
   "devDependencies": {
     "@types/node": "^24.0.15",
+    "@types/node-cron": "^3.0.11",
     "@types/node-fetch": "^2.6.12",
     "ts-node": "^10.9.1",
     "typescript": "^5.3.3"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
 import { Client, GatewayIntentBits, Collection } from 'discord.js';
+import cron from 'node-cron';
+import { syncInGameGuilds } from './tasks/guild-sync';
 import dotenv from 'dotenv';
 import path from 'node:path';
 import fs from 'node:fs';
@@ -42,5 +44,13 @@ registerReady(client);
 registerInteractionCreate(client, commands, supabase);
 registerGuildMemberUpdate(client);
 registerGuildCreate(client);
+
+client.once('ready', () => {
+  // Schedule the smart guild sync task to run every 3 hours.
+  // '0 */3 * * *' means "at minute 0 past every 3rd hour"
+  cron.schedule('0 */3 * * *', () => {
+    syncInGameGuilds(client);
+  });
+});
 
 client.login(DISCORD_TOKEN);

--- a/src/tasks/guild-sync.ts
+++ b/src/tasks/guild-sync.ts
@@ -1,0 +1,108 @@
+import { Client } from 'discord.js';
+import { supabase } from '../supabaseClient';
+import fetch from 'node-fetch';
+
+// Define a type for our player data for clarity
+type Player = {
+    id: number;
+    discord_id: string;
+    character_name: string;
+    guild_id: string;
+};
+
+export async function syncInGameGuilds(client: Client): Promise<void> {
+    console.log('Running smart in-game guild sync...');
+
+    try {
+        // 1. Fetch all guild configurations from the database
+        const { data: configs, error: configError } = await supabase
+            .from('guild_configs')
+            .select('*');
+
+        if (configError) throw configError;
+        if (!configs || configs.length === 0) {
+            console.log('No guilds are configured for guild sync. Skipping task.');
+            return;
+        }
+
+        // 2. Loop through each configured guild and process it
+        for (const config of configs) {
+            const { guild_id, name: inGameGuildName, realm } = config;
+            if (!inGameGuildName || !realm) {
+                console.log(`Skipping server ${guild_id} due to incomplete configuration.`);
+                continue;
+            }
+
+            console.log(`--- Syncing for server ${guild_id} (In-game: ${inGameGuildName}) ---`);
+
+            // 3. Fetch the In-Game Roster from Warmane API
+            const response = await fetch(`https://armory.warmane.com/api/guild/${encodeURIComponent(inGameGuildName)}/${encodeURIComponent(realm)}/summary`);
+            if (!response.ok) {
+                console.error(`Error fetching guild data for '${inGameGuildName}'.`);
+                continue;
+            }
+            const guildData = await response.json();
+            if (guildData.error) {
+                console.error(`API error for '${inGameGuildName}': ${guildData.error}`);
+                continue;
+            }
+            const inGameMembers = new Set(guildData.roster.map((m: any) => m.name.toLowerCase()));
+            console.log(`Found ${inGameMembers.size} members in the in-game guild.`);
+
+            // 4. Fetch all registered players for this specific Discord server
+            const { data: registeredPlayersData, error: playersError } = await supabase
+                .from('players')
+                .select('*')
+                .eq('guild_id', guild_id);
+
+            const registeredPlayers = (registeredPlayersData ?? []) as Player[];
+            
+            if (playersError) throw playersError;
+
+            // 5. Group players by their Discord ID
+            const playersByDiscordId = new Map<string, Player[]>();
+            for (const player of registeredPlayers) {
+                const existing = playersByDiscordId.get(player.discord_id) || [];
+                existing.push(player);
+                playersByDiscordId.set(player.discord_id, existing);
+            }
+
+            const discordGuild = client.guilds.cache.get(guild_id);
+            if (!discordGuild) continue;
+
+            // 6. Process each unique Discord user based on the new logic
+            for (const [discordId, characters] of playersByDiscordId.entries()) {
+                const remainingChars = characters.filter(c => inGameMembers.has(c.character_name.toLowerCase()));
+                const staleChars = characters.filter(c => !inGameMembers.has(c.character_name.toLowerCase()));
+
+                if (remainingChars.length === 0) {
+                    // CASE A: User has NO characters left in the guild. Remove them completely.
+                    console.log(`User ${discordId} has no characters left in the guild. Removing roles and all data.`);
+                    
+                    try {
+                        const member = await discordGuild.members.fetch(discordId);
+                        const rolesToRemove = [config.member_role_id, config.raider_role_id, config.class_leader_role_id, config.officer_role_id].filter(id => id) as string[];
+                        if (member && rolesToRemove.length > 0) {
+                            await member.roles.remove(rolesToRemove, 'All characters have left the in-game guild.');
+                        }
+                    } catch (e) { console.log(`Could not fetch member ${discordId} to remove roles.`); }
+
+                    // Delete all their character records from DB
+                    const charIdsToDelete = characters.map(c => c.id);
+                    await supabase.from('players').delete().in('id', charIdsToDelete);
+
+                } else if (staleChars.length > 0) {
+                    // CASE B: User has alts that left. Clean up only the alt records.
+                    console.log(`User ${discordId} has left on some alts. Cleaning up stale records.`);
+                    
+                    const staleCharIds = staleChars.map(c => c.id);
+                    await supabase.from('players').delete().in('id', staleCharIds);
+                    console.log(`Removed ${staleCharIds.length} stale character(s) for user ${discordId}.`);
+                }
+            }
+        }
+    } catch (error) {
+        console.error('An unexpected error occurred during the smart guild sync task:', error);
+    }
+    console.log('--- Smart in-game guild sync finished. ---');
+}


### PR DESCRIPTION
## Summary
- add automated guild roster syncing task
- schedule guild sync every 3 hours in the main bot
- include node-cron and typings

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687d989d574c83249ebb840fd1c8feeb