### PR TITLE
Align queries with new schema

### DIFF
--- a/src/commands/character.ts
+++ b/src/commands/character.ts
@@ -33,7 +33,8 @@ async function viewCharacters(interaction: ChatInputCommandInteraction) {
   const { data: characters, error } = await supabase
     .from('players')
     .select('character_name, realm')
-    .eq('discord_id', discordId);
+    .eq('discord_id', discordId)
+    .eq('guild_id', interaction.guildId ?? '');
 
   if (error) {
     await interaction.editReply({ content: 'There was an error fetching your characters.' });
@@ -53,7 +54,8 @@ async function deleteCharacter(interaction: ChatInputCommandInteraction) {
   const { data: characters, error } = await supabase
     .from('players')
     .select('id, character_name, realm')
-    .eq('discord_id', discordId);
+    .eq('discord_id', discordId)
+    .eq('guild_id', interaction.guildId ?? '');
 
   if (error || !characters || characters.length === 0) {
     await interaction.editReply({ content: 'You have no characters to delete.' });

--- a/src/commands/raid.ts
+++ b/src/commands/raid.ts
@@ -108,7 +108,7 @@ const command: Command = {
     } else if (sub === 'list') {
       const now = new Date().toISOString();
       const { data: raids } = await supabase
-        .from('Raids')
+        .from('raids')
         .select('*')
         .gt('scheduled_date', now)
         .order('scheduled_date', { ascending: true });
@@ -121,7 +121,7 @@ const command: Command = {
       const embed = new EmbedBuilder().setTitle('Upcoming Raids');
       for (const raid of raids as Raid[]) {
         const { data: signups } = await supabase
-          .from('RaidSignups')
+          .from('raid_signups')
           .select('id')
           .eq('raid_id', raid.id);
         const count = signups?.length ?? 0;
@@ -142,7 +142,7 @@ const command: Command = {
 
       const id = interaction.options.getString('id', true);
       const { data: raid } = await supabase
-        .from('Raids')
+        .from('raids')
         .delete()
         .eq('id', id)
         .select('signup_message_id')
@@ -187,14 +187,14 @@ export async function handleRaidCreateModal(
 
   let raidLeaderId: string | null = null;
   const { data: player } = await supabase
-    .from('Players')
+    .from('players')
     .select('id')
     .eq('discord_id', interaction.user.id)
     .maybeSingle();
   if (player) raidLeaderId = player.id;
 
   const { data: raid } = await supabase
-    .from('Raids')
+    .from('raids')
     .insert({
       title,
       instance,
@@ -226,7 +226,7 @@ export async function handleRaidCreateModal(
   }
   const msg = await channel.send({ embeds: [embed], components: [buttons] });
 
-  await supabase.from('Raids').update({ signup_message_id: msg.id }).eq('id', raid.id);
+  await supabase.from('raids').update({ signup_message_id: msg.id }).eq('id', raid.id);
 
   await interaction.reply({ content: 'Raid created.', ephemeral: true });
 }

--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -1,20 +1,16 @@
 import {
   SlashCommandBuilder,
   ChatInputCommandInteraction,
-  MessageFlags,
-  ButtonBuilder,
-  ButtonStyle,
-  ActionRowBuilder,
-  StringSelectMenuBuilder,
   ModalBuilder,
   TextInputBuilder,
   TextInputStyle,
-  ComponentType,
+  ActionRowBuilder,
+  MessageFlags,
 } from 'discord.js';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { Command } from '../types';
-import { calculateGearScore } from '../gearscore-calculator';
 import { fetchCharacterSummary } from '../utils/warmane-api';
+import { calculateGearScore } from '../gearscore-calculator';
 
 const command: Command = {
   data: new SlashCommandBuilder()
@@ -22,185 +18,74 @@ const command: Command = {
     .setDescription('Register a character'),
 
   async execute(interaction: ChatInputCommandInteraction, supabase: SupabaseClient) {
-    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-
-    const { data: player } = await supabase
-      .from('Players')
-      .select('id')
-      .eq('discord_id', interaction.user.id)
-      .maybeSingle();
-
-    if (!player) {
-      const button = new ButtonBuilder()
-        .setCustomId('register_main')
-        .setLabel('Register Main Character')
-        .setStyle(ButtonStyle.Primary);
-      const row = new ActionRowBuilder<ButtonBuilder>().addComponents(button);
-
-      const msg = await interaction.editReply({
-        content: "Welcome! Let's get your main character registered.",
-        components: [row],
-      });
-
-      try {
-        const click = await msg.awaitMessageComponent({
-          componentType: ComponentType.Button,
-          filter: (i) => i.customId === 'register_main' && i.user.id === interaction.user.id,
-          time: 60_000,
-        });
-
-        const modal = new ModalBuilder()
-          .setCustomId('register_modal')
-          .setTitle('Register Character')
-          .addComponents(
-            new ActionRowBuilder<TextInputBuilder>().addComponents(
-              new TextInputBuilder()
-                .setCustomId('character_name')
-                .setLabel('Character Name')
-                .setStyle(TextInputStyle.Short)
-                .setRequired(true)
-            ),
-            new ActionRowBuilder<TextInputBuilder>().addComponents(
-              new TextInputBuilder()
-                .setCustomId('realm')
-                .setLabel('Realm')
-                .setStyle(TextInputStyle.Short)
-                .setRequired(true)
-            )
-          );
-
-        await click.showModal(modal);
-        const modalSubmit = await click.awaitModalSubmit({
-          filter: (i) => i.customId === 'register_modal' && i.user.id === interaction.user.id,
-          time: 60_000,
-        });
-        await modalSubmit.deferUpdate();
-
-        const name = modalSubmit.fields.getTextInputValue('character_name').trim();
-        const realm = modalSubmit.fields.getTextInputValue('realm').trim();
-        try {
-          const summary = await fetchCharacterSummary(name, realm);
-          if (summary.error) {
-            await interaction.editReply({
-              content: `Warmane API error: ${summary.error}`,
-              components: [],
-            });
-            return;
-          }
-          const gearScore = calculateGearScore(summary.equipment);
-          const { error } = await supabase.from('Players').insert({
-            discord_id: interaction.user.id,
-            main_character: name,
-            realm,
-          });
-          if (error) throw error;
-
-          const armoryUrl = `https://armory.warmane.com/character/${encodeURIComponent(name)}/${encodeURIComponent(realm)}`;
-          await interaction.editReply({
-            content: `Registered **[${summary.name}](${armoryUrl})** on ${summary.realm}! GearScore: **${gearScore}**`,
-            components: [],
-          });
-        } catch (err) {
-          console.error('Register main error:', err);
-          await interaction.editReply({
-            content: 'Failed to register character.',
-            components: [],
-          });
-        }
-      } catch {
-        await interaction.editReply({ content: 'Registration timed out.', components: [] });
-      }
+    if (!interaction.guildId) {
+      await interaction.reply({ content: 'This command can only be used in a server.', ephemeral: true });
       return;
     }
 
-    const menu = new StringSelectMenuBuilder()
-      .setCustomId('register_select')
-      .setPlaceholder('Choose an option')
-      .addOptions(
-        { label: 'Register a new Alt', value: 'register_alt' },
-        { label: 'Manage my Characters', value: 'manage_chars' }
+    const modal = new ModalBuilder()
+      .setCustomId('register_modal')
+      .setTitle('Register Character')
+      .addComponents(
+        new ActionRowBuilder<TextInputBuilder>().addComponents(
+          new TextInputBuilder()
+            .setCustomId('character_name')
+            .setLabel('Character Name')
+            .setStyle(TextInputStyle.Short)
+            .setRequired(true),
+        ),
+        new ActionRowBuilder<TextInputBuilder>().addComponents(
+          new TextInputBuilder()
+            .setCustomId('realm')
+            .setLabel('Realm')
+            .setStyle(TextInputStyle.Short)
+            .setRequired(true),
+        ),
       );
-    const row = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu);
 
-    const msg = await interaction.editReply({
-      content: 'You already have a main registered. What would you like to do?',
-      components: [row],
-    });
+    await interaction.showModal(modal);
 
     try {
-      const select = await msg.awaitMessageComponent({
-        componentType: ComponentType.StringSelect,
-        filter: (i) => i.customId === 'register_select' && i.user.id === interaction.user.id,
-        time: 60_000,
-      });
-
-      if (select.values[0] === 'manage_chars') {
-        await select.update({
-          content: 'Use /character view or /character delete to manage your characters.',
-          components: [],
-        });
-        return;
-      }
-
-      const modal = new ModalBuilder()
-        .setCustomId('register_modal')
-        .setTitle('Register Character')
-        .addComponents(
-          new ActionRowBuilder<TextInputBuilder>().addComponents(
-            new TextInputBuilder()
-              .setCustomId('character_name')
-              .setLabel('Character Name')
-              .setStyle(TextInputStyle.Short)
-              .setRequired(true)
-          ),
-          new ActionRowBuilder<TextInputBuilder>().addComponents(
-            new TextInputBuilder()
-              .setCustomId('realm')
-              .setLabel('Realm')
-              .setStyle(TextInputStyle.Short)
-              .setRequired(true)
-          )
-        );
-
-      await select.showModal(modal);
-      const modalSubmit = await select.awaitModalSubmit({
+      const submit = await interaction.awaitModalSubmit({
         filter: (i) => i.customId === 'register_modal' && i.user.id === interaction.user.id,
         time: 60_000,
       });
-      await modalSubmit.deferUpdate();
 
-      const name = modalSubmit.fields.getTextInputValue('character_name').trim();
-      const realm = modalSubmit.fields.getTextInputValue('realm').trim();
+      await submit.deferReply({ ephemeral: true });
+
+      const name = submit.fields.getTextInputValue('character_name').trim();
+      const realm = submit.fields.getTextInputValue('realm').trim();
+
       try {
         const summary = await fetchCharacterSummary(name, realm);
         if (summary.error) {
-          await interaction.editReply({
-            content: `Warmane API error: ${summary.error}`,
-            components: [],
-          });
+          await submit.editReply({ content: `Warmane API error: ${summary.error}` });
           return;
         }
         const gearScore = calculateGearScore(summary.equipment);
-        const { error } = await supabase.from('Alts').insert({
-          player_id: player.id,
+        const { error } = await supabase.from('players').insert({
+          guild_id: interaction.guildId,
+          discord_id: interaction.user.id,
           character_name: name,
+          realm,
+          gear_score: gearScore,
+          last_updated: new Date().toISOString(),
         });
-        if (error) throw error;
+        if (error) {
+          await submit.editReply({ content: `Database error: ${error.message}` });
+          return;
+        }
 
         const armoryUrl = `https://armory.warmane.com/character/${encodeURIComponent(name)}/${encodeURIComponent(realm)}`;
-        await interaction.editReply({
-          content: `Registered alt **[${summary.name}](${armoryUrl})** on ${summary.realm}! GearScore: **${gearScore}**`,
-          components: [],
+        await submit.editReply({
+          content: `Registered **[${summary.name}](${armoryUrl})** on ${summary.realm}! GearScore: **${gearScore}**`,
         });
       } catch (err) {
-        console.error('Register alt error:', err);
-        await interaction.editReply({
-          content: 'Failed to register alt.',
-          components: [],
-        });
+        console.error('Register character error:', err);
+        await submit.editReply({ content: 'Failed to register character.' });
       }
     } catch {
-      await interaction.editReply({ content: 'Registration timed out.', components: [] });
+      await interaction.followUp({ content: 'Registration timed out.', ephemeral: true, flags: MessageFlags.Ephemeral });
     }
   },
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,19 +10,24 @@ export interface Command {
 
 export interface Player {
   id: string;
+  guild_id: string;
   discord_id: string;
-  main_character: string;
+  character_name: string;
   realm: string;
+  gear_score?: number | null;
+  last_updated?: string | null;
   created_at?: string;
-  updated_at?: string;
 }
 
 export interface Character {
+  id: string;
+  guild_id: string;
+  discord_id: string;
   character_name: string;
-  player_id?: string;
-  gear_score?: number;
-  item_level?: number;
-  last_updated?: string;
+  realm: string;
+  gear_score?: number | null;
+  last_updated?: string | null;
+  created_at?: string;
 }
 
 export interface Raid {

--- a/src/utils/button-handlers.ts
+++ b/src/utils/button-handlers.ts
@@ -20,49 +20,18 @@ export async function handleRaidSignupButton(
 ) {
   const [, raidId] = interaction.customId.split(':');
 
-  const { data: player } = await supabase
-    .from('Players')
-    .select('id, main_character')
-    .eq('discord_id', interaction.user.id)
-    .maybeSingle();
-  if (!player) {
-    await interaction.reply({ content: 'Register a main character first.', ephemeral: true });
-    return;
-  }
-
-  const { data: alts } = await supabase
-    .from('Alts')
-    .select('character_name')
-    .eq('player_id', player.id);
-
-  const characters = [player.main_character, ...(alts?.map(a => a.character_name) ?? [])];
-  if (characters.length === 0) {
-    await interaction.reply({ content: 'Register a character first.', ephemeral: true });
-    return;
-  }
-
-  const { data: gsRows } = await supabase
-    .from('GearScores')
-    .select('character_name, gear_score')
-    .in('character_name', characters);
-  const gsMap = new Map<string, number>();
-  gsRows?.forEach(row => {
-    if (row.gear_score) gsMap.set(row.character_name, row.gear_score);
-  });
-
-  const select = new StringSelectMenuBuilder()
-    .setCustomId(CHAR_SELECT_ID(raidId))
-    .setPlaceholder('Select character')
-    .addOptions(
-      characters.map(name => ({
-        label: name,
-        value: name,
-        description: gsMap.has(name) ? `${gsMap.get(name)} GS` : 'No GS set',
-      }))
+  try {
+    const { menu } = await buildCharacterSelectMenu(
+      supabase,
+      interaction.user.id,
+      interaction.guildId ?? '',
+      CHAR_SELECT_ID(raidId)
     );
-
-  const row = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select);
-  await interaction.reply({ content: 'Choose your character:', components: [row], ephemeral: true });
+    const row = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu);
+    await interaction.reply({ content: 'Choose your character:', components: [row], ephemeral: true });
+  } catch {
+    await interaction.reply({ content: 'Register a character first.', ephemeral: true });
+  }
 }
 
 export async function handleRaidRoleSelect(
@@ -72,7 +41,7 @@ export async function handleRaidRoleSelect(
   const [, raidId] = interaction.customId.split(':');
   const role = interaction.values[0] as 'tank' | 'healer' | 'dps';
 
-  const { data: raid } = await supabase.from('Raids').select('*').eq('id', raidId).maybeSingle();
+  const { data: raid } = await supabase.from('raids').select('*').eq('id', raidId).maybeSingle();
   if (!raid) {
     await interaction.update({ content: 'Raid not found.', components: [] });
     return;
@@ -81,6 +50,7 @@ export async function handleRaidRoleSelect(
     const { menu, characters } = await buildCharacterSelectMenu(
       supabase,
       interaction.user.id,
+      interaction.guildId ?? '',
       CHAR_SELECT_ID(raidId)
     );
 
@@ -105,18 +75,20 @@ async function signupCharacter(
   role: 'tank' | 'healer' | 'dps',
 ) {
   const { data: gs } = await supabase
-    .from('GearScores')
+    .from('players')
     .select('gear_score')
+    .eq('guild_id', interaction.guildId ?? '')
+    .eq('discord_id', interaction.user.id)
     .eq('character_name', character)
     .maybeSingle();
 
   await supabase
-    .from('RaidSignups')
+    .from('raid_signups')
     .delete()
     .eq('raid_id', raidId)
     .eq('character_name', character);
 
-  await supabase.from('RaidSignups').insert({
+  await supabase.from('raid_signups').insert({
     raid_id: raidId,
     character_name: character,
     role,
@@ -124,7 +96,7 @@ async function signupCharacter(
   });
 
   const { data: signups } = await supabase
-    .from('RaidSignups')
+    .from('raid_signups')
     .select('*')
     .eq('raid_id', raidId);
 
@@ -150,7 +122,7 @@ export async function handleRaidCharacterSelect(
   const [, raidId] = interaction.customId.split(':');
   const character = interaction.values[0];
 
-  const { data: raid } = await supabase.from('Raids').select('*').eq('id', raidId).maybeSingle();
+  const { data: raid } = await supabase.from('raids').select('*').eq('id', raidId).maybeSingle();
   if (!raid) {
     await interaction.update({ content: 'Raid not found.', components: [] });
     return;
@@ -165,40 +137,32 @@ export async function handleRaidLeaveButton(
 ) {
   const [, raidId] = interaction.customId.split(':');
 
-  const { data: raid } = await supabase.from('Raids').select('*').eq('id', raidId).maybeSingle();
+  const { data: raid } = await supabase.from('raids').select('*').eq('id', raidId).maybeSingle();
   if (!raid) {
     await interaction.reply({ content: 'Raid not found.', ephemeral: true });
     return;
   }
 
-  const { data: player } = await supabase
-    .from('Players')
-    .select('id, main_character')
+  const { data: rows } = await supabase
+    .from('players')
+    .select('character_name')
     .eq('discord_id', interaction.user.id)
-    .maybeSingle();
-  if (!player) {
-    await interaction.reply({ content: 'Register a main character first.', ephemeral: true });
+    .eq('guild_id', interaction.guildId ?? '');
+
+  const characters = rows?.map(r => r.character_name) ?? [];
+  if (characters.length === 0) {
+    await interaction.reply({ content: 'Register a character first.', ephemeral: true });
     return;
   }
 
-  const { data: alts } = await supabase
-    .from('Alts')
-    .select('character_name')
-    .eq('player_id', player.id);
-
-  const characters = [
-    player.main_character,
-    ...((alts?.map(a => a.character_name)) ?? [])
-  ];
-
   await supabase
-    .from('RaidSignups')
+    .from('raid_signups')
     .delete()
     .eq('raid_id', raidId)
     .in('character_name', characters);
 
   const { data: signups } = await supabase
-    .from('RaidSignups')
+    .from('raid_signups')
     .select('*')
     .eq('raid_id', raidId);
 

--- a/src/utils/character-select.ts
+++ b/src/utils/character-select.ts
@@ -13,32 +13,30 @@ export interface CharacterSelectResult {
 export async function buildCharacterSelectMenu(
   supabase: SupabaseClient,
   discordId: string,
+  guildId: string,
   customId: string,
   placeholder = 'Select character'
 ): Promise<CharacterSelectResult> {
-  const { data: player } = await supabase
-    .from('Players')
-    .select('id, main_character')
+  const { data } = await supabase
+    .from('players')
+    .select('character_name, gear_score')
     .eq('discord_id', discordId)
-    .maybeSingle();
-  if (!player) {
-    throw new Error('No characters registered');
-  }
+    .eq('guild_id', guildId);
 
-  const { data: alts } = await supabase
-    .from('Alts')
-    .select('character_name')
-    .eq('player_id', player.id);
-
-  const characters = [player.main_character, ...(alts?.map(a => a.character_name) ?? [])];
-  if (characters.length === 0) {
+  if (!data || data.length === 0) {
     throw new Error('No characters registered');
   }
 
   const menu = new StringSelectMenuBuilder()
     .setCustomId(customId)
     .setPlaceholder(placeholder)
-    .addOptions(characters.map(c => ({ label: c, value: c })));
+    .addOptions(
+      data.map((c) => ({
+        label: c.character_name,
+        value: c.character_name,
+        description: c.gear_score ? `${c.gear_score} GS` : 'No GS set',
+      }))
+    );
 
-  return { menu, characters };
+  return { menu, characters: data.map((c) => c.character_name) };
 }


### PR DESCRIPTION
## Summary
- update registration flow to use `players` table
- save gear scores in `players.gear_score`
- adjust GS commands to read/write from `players`
- refactor raid signup handlers for new schema
- clean up role sync logic
- update helper utilities and types

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687da5b824848324ae668141444d168b