### PR TITLE
Improve gearscore calculator debugging

### DIFF
--- a/docs/items.example.json
+++ b/docs/items.example.json
@@ -1,0 +1,5 @@
+[
+  { "itemId": 12345, "itemLevel": 200, "slot": "Head" },
+  { "itemId": 67890, "itemLevel": 213, "slot": "Chest" },
+  { "itemId": 11111, "itemLevel": 232, "slot": "Weapon" }
+]

--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -62,6 +62,7 @@ const command: Command = {
           await submit.editReply({ content: `Warmane API error: ${summary.error}` });
           return;
         }
+        console.log('Warmane equipment data:', summary.equipment);
         const gearScore = calculateGearScore(summary.equipment);
         const { error } = await supabase.from('players').insert({
           guild_id: interaction.guildId,

--- a/src/utils/gearscore-calculator.ts
+++ b/src/utils/gearscore-calculator.ts
@@ -16,9 +16,13 @@ class GearScoreCalculator {
   }
 
   private loadItemData() {
+    const jsonPath = path.join(process.cwd(), 'items.min.json');
+    console.log(`Loading items from ${jsonPath}`);
     try {
-      // Assumes equippable_items.json is in the project's root directory
-      const jsonPath = path.join(__dirname, '../../items.min.json');
+      if (!fs.existsSync(jsonPath)) {
+        console.error(`Items file not found at ${jsonPath}`);
+        return;
+      }
       const fileContent = fs.readFileSync(jsonPath, 'utf-8');
       const itemList: Item[] = JSON.parse(fileContent);
 
@@ -27,12 +31,13 @@ class GearScoreCalculator {
       }
       console.log(`Loaded ${this.items.size} items into the GearScore calculator.`);
     } catch (error) {
-      console.error('Failed to load or parse equippable_items.json:', error);
+      console.error('Failed to load or parse items.min.json:', error);
     }
   }
 
   // The 'equippedItems' array comes from the Warmane API response
   public calculate(equippedItems: { name: string; itemID: string }[]): number {
+    console.log('Calculating GearScore for equipment:', equippedItems);
     let totalScore = 0;
     if (!equippedItems) return 0;
 
@@ -40,14 +45,21 @@ class GearScoreCalculator {
       const itemId = parseInt(equippedItem.itemID, 10);
       const itemData = this.items.get(itemId);
 
-      if (itemData) {
-        const slot = itemData.slot;
-        const weight = GEAR_SLOT_WEIGHTS[slot] || 0;
-        if (weight > 0) {
-          totalScore += itemData.itemLevel * weight;
-        }
+      if (!itemData) {
+        console.warn(`Item ID ${itemId} not found in items map`);
+        continue;
+      }
+
+      const slot = itemData.slot;
+      const weight = GEAR_SLOT_WEIGHTS[slot] || 0;
+      if (weight > 0) {
+        totalScore += itemData.itemLevel * weight;
+        console.log(`Added ${itemData.itemLevel} * ${weight} for slot ${slot} (ID ${itemId})`);
+      } else {
+        console.log(`Slot ${slot} (ID ${itemId}) has no weight`);
       }
     }
+    console.log('Final GearScore:', Math.round(totalScore));
     return Math.round(totalScore);
   }
 }


### PR DESCRIPTION
## Summary
- log items load status and path in gearscore calculator
- report missing item IDs during calculation
- show Warmane equipment in register command
- add small example items JSON

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687da9ae41188324b08c678063022d4a