### PR TITLE
Fix item field for GearScore

### DIFF
--- a/src/gearscore-calculator.ts
+++ b/src/gearscore-calculator.ts
@@ -1,5 +1,5 @@
 import { gearScoreCalculator } from './utils/gearscore-calculator';
 
-export function calculateGearScore(equipment: { name: string; itemID: string }[]): number {
+export function calculateGearScore(equipment: { name: string; item: string; transmog?: string }[]): number {
   return gearScoreCalculator.calculate(equipment);
 }

--- a/src/utils/gearscore-calculator.ts
+++ b/src/utils/gearscore-calculator.ts
@@ -36,13 +36,13 @@ class GearScoreCalculator {
   }
 
   // The 'equippedItems' array comes from the Warmane API response
-  public calculate(equippedItems: { name: string; itemID: string }[]): number {
+  public calculate(equippedItems: { name: string; item: string; transmog?: string }[]): number {
     console.log('Calculating GearScore for equipment:', equippedItems);
     let totalScore = 0;
     if (!equippedItems) return 0;
 
     for (const equippedItem of equippedItems) {
-      const itemId = parseInt(equippedItem.itemID, 10);
+      const itemId = parseInt(equippedItem.item, 10);
       const itemData = this.items.get(itemId);
 
       if (!itemData) {


### PR DESCRIPTION
## Summary
- warmane API uses `item`, not `itemID`
- update gear score calculation to parse the correct field
- adjust type signatures for the wrapper and utility

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687dac3b902883249f6bdff1c159d143