### PR TITLE
Fix raid modal slots and add error logger

### DIFF
--- a/src/commands/raid.ts
+++ b/src/commands/raid.ts
@@ -81,26 +81,10 @@ const command: Command = {
           ),
           new ActionRowBuilder<TextInputBuilder>().addComponents(
             new TextInputBuilder()
-              .setCustomId('tank_slots')
-              .setLabel('Tank slots needed')
+              .setCustomId('slots')
+              .setLabel('Role Slots (tanks/healers/dps)')
               .setStyle(TextInputStyle.Short)
-              .setValue('2')
-              .setRequired(true)
-          ),
-          new ActionRowBuilder<TextInputBuilder>().addComponents(
-            new TextInputBuilder()
-              .setCustomId('healer_slots')
-              .setLabel('Healer slots needed')
-              .setStyle(TextInputStyle.Short)
-              .setValue('6')
-              .setRequired(true)
-          ),
-          new ActionRowBuilder<TextInputBuilder>().addComponents(
-            new TextInputBuilder()
-              .setCustomId('dps_slots')
-              .setLabel('DPS slots needed')
-              .setStyle(TextInputStyle.Short)
-              .setValue('17')
+              .setValue('2/6/17')
               .setRequired(true)
           )
         );
@@ -181,9 +165,11 @@ export async function handleRaidCreateModal(
   const title = interaction.fields.getTextInputValue('title');
   const instance = interaction.fields.getTextInputValue('instance');
   const date = interaction.fields.getTextInputValue('datetime');
-  const tankSlots = parseInt(interaction.fields.getTextInputValue('tank_slots'), 10) || 2;
-  const healerSlots = parseInt(interaction.fields.getTextInputValue('healer_slots'), 10) || 6;
-  const dpsSlots = parseInt(interaction.fields.getTextInputValue('dps_slots'), 10) || 17;
+  const slotsRaw = interaction.fields.getTextInputValue('slots');
+  const [tankStr, healerStr, dpsStr] = slotsRaw.split(/[\s,/]+/);
+  const tankSlots = parseInt(tankStr, 10) || 2;
+  const healerSlots = parseInt(healerStr, 10) || 6;
+  const dpsSlots = parseInt(dpsStr, 10) || 17;
 
   let raidLeaderId: string | null = null;
   const { data: player } = await supabase

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -9,6 +9,7 @@ import {
   handleRaidCharacterSelect,
 } from '../utils/button-handlers';
 import { handleGsSetSelectMenu } from '../commands/gs';
+import { logError } from '../utils/logger';
 
 export default function registerInteractionCreate(client: Client, commands: Map<string, Command>, supabase: SupabaseClient) {
   client.on(Events.InteractionCreate, async (interaction) => {
@@ -18,7 +19,7 @@ export default function registerInteractionCreate(client: Client, commands: Map<
       try {
         await command.execute(interaction, supabase);
       } catch (err) {
-        console.error('Command error:', err);
+        logError(err);
         if (!interaction.replied) {
           await interaction.reply({ content: 'An error occurred.', ephemeral: true });
         }

--- a/src/utils/embed-builder.ts
+++ b/src/utils/embed-builder.ts
@@ -32,7 +32,8 @@ export function buildRaidEmbed(
         const name = encodeURIComponent(s.character_name);
         const realmEnc = encodeURIComponent(realm);
         const link = `[${s.character_name}](https://armory.warmane.com/character/${name}/${realmEnc})`;
-        return `• ${link}${s.gear_score ? ` - ${s.gear_score} GS` : ''}`;
+        const gsText = typeof s.gear_score === 'number' ? `${s.gear_score} GS` : 'No GS';
+        return `• ${link} - ${gsText}`;
       });
     const open = max - members.length;
     if (open > 0) {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,21 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const logDir = path.resolve(__dirname, '../../logs');
+const logFile = path.join(logDir, 'errors.log');
+
+function ensureLogDir() {
+  if (!fs.existsSync(logDir)) {
+    fs.mkdirSync(logDir, { recursive: true });
+  }
+}
+
+export function logError(error: unknown) {
+  ensureLogDir();
+  const timestamp = new Date().toISOString();
+  const type = (error as any)?.name || 'Error';
+  const stack = (error instanceof Error && error.stack) ? error.stack : String(error);
+  const msg = `[${timestamp}] ${type}: ${stack}\n`;
+  fs.appendFileSync(logFile, msg);
+  console.error(msg);
+}


### PR DESCRIPTION
## Summary
- combine tank, healer, and dps slot inputs into one field
- show GS for all players on raid embeds
- add simple file logger and log command errors

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687db0175f708324b79b65adaa213ae1