### PR TITLE
Fix role sync thrashing

### DIFF
--- a/src/events/guildMemberUpdate.ts
+++ b/src/events/guildMemberUpdate.ts
@@ -1,11 +1,11 @@
 import { Client, Events } from 'discord.js';
-import { syncMemberRoles } from '../utils/role-sync';
+import { syncUserRoles } from '../utils/role-sync';
 import { getGuildConfig } from '../utils/guild-config';
 
 export default function registerGuildMemberUpdate(client: Client) {
   client.on(Events.GuildMemberUpdate, async (_, newMember) => {
     const config = await getGuildConfig(newMember.guild.id);
     if (!config || !config.warmane_guild_name || !config.member_role_id) return;
-    await syncMemberRoles(newMember);
+    await syncUserRoles(newMember);
   });
 }


### PR DESCRIPTION
## Summary
- use `syncUserRoles` on member updates so we don't keep removing roles for active guild members

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687db5b813748324a7aef42c886902e6