### PR TITLE
Fix register modal label length

### DIFF
--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -41,7 +41,7 @@ const command: Command = {
         new ActionRowBuilder<TextInputBuilder>().addComponents(
           new TextInputBuilder()
             .setCustomId('character_name')
-            .setLabel('Character Name (case sensitive - exact in-game)')
+            .setLabel('Character Name (exact - case sensitive)')
             .setPlaceholder('e.g. Arth\u00e1s')
             .setStyle(TextInputStyle.Short)
             .setRequired(true),


### PR DESCRIPTION
## Summary
- shorten the `/register` modal label to meet Discord limits

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687e454e2e808324b5491e81795169e9