### PR TITLE
Implement Warmane guild cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 .env
 .DS_Store
 *.log
+cache/


### PR DESCRIPTION
## Summary
- cache guild roster and summary responses in `cache/`
- return cached roster when younger than an hour and include dictionary keyed by name
- ignore cache folder in git

## Testing
- `npm ci`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_b_687e4e10c6bc832495aaa7195029638f