### PR TITLE
Potential fix for code scanning alert no. 4: Unused variable, import, function or class

### DIFF
--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -1,7 +1,6 @@
 import {
   SlashCommandBuilder,
   ChatInputCommandInteraction,
-  PermissionFlagsBits,
   EmbedBuilder,
   ChannelType,
   DMChannel,


### PR DESCRIPTION
Potential fix for [https://github.com/RonPoly/raid-bot/security/code-scanning/4](https://github.com/RonPoly/raid-bot/security/code-scanning/4)

To fix the problem, we should remove `PermissionFlagsBits` from the import statement on line 4 in `src/commands/setup.ts`. This does not affect any existing functionality since the imported symbol is not referenced anywhere in the file. This change is local and does not require any additional imports, code definitions, or dependency changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
