### PR TITLE
Implement caching and rate limiting for Warmane API

### DIFF
--- a/src/utils/warmane-api.ts
+++ b/src/utils/warmane-api.ts
@@ -3,6 +3,39 @@ import path from 'path';
 
 const BASE_URL = 'https://armory.warmane.com/api';
 
+// Simple token bucket rate limiter
+let tokens = 10;
+let lastCall = 0;
+const queue: Array<() => void> = [];
+
+function processQueue() {
+  if (queue.length === 0 || tokens <= 0) return;
+  const now = Date.now();
+  if (now - lastCall < 100) {
+    setTimeout(processQueue, 100 - (now - lastCall));
+    return;
+  }
+  const resolve = queue.shift()!;
+  tokens--;
+  lastCall = now;
+  resolve();
+  if (queue.length > 0) {
+    setTimeout(processQueue, 100);
+  }
+}
+
+setInterval(() => {
+  tokens = Math.min(tokens + 1, 10);
+  processQueue();
+}, 6000);
+
+async function rateLimit() {
+  return new Promise<void>((resolve) => {
+    queue.push(resolve);
+    processQueue();
+  });
+}
+
 const CACHE_DIR = path.join(__dirname, '../../cache');
 
 function slugify(value: string): string {
@@ -15,6 +48,10 @@ function rosterCachePath(name: string, realm: string): string {
 
 function summaryCachePath(name: string, realm: string): string {
   return path.join(CACHE_DIR, `${slugify(name)}_${slugify(realm)}_summary.json`);
+}
+
+function characterCachePath(name: string, realm: string): string {
+  return path.join(CACHE_DIR, `${slugify(name)}_${slugify(realm)}_character.json`);
 }
 
 async function readCache(file: string, maxAgeMs: number) {
@@ -58,6 +95,7 @@ export async function fetchGuildMembers(name: string, realm: string) {
 
   const url = `${BASE_URL}/guild/${encodeGuildName(name)}/${encodeURIComponent(realm)}/members`;
   console.log('[WarmaneAPI] Fetching guild members from', url);
+  await rateLimit();
   const res = await fetch(url);
   if (res.status === 503) {
     const err: any = new Error('Warmane API maintenance');
@@ -80,11 +118,30 @@ export async function fetchGuildMembers(name: string, realm: string) {
 }
 
 export async function fetchCharacterSummary(name: string, realm: string) {
-  const res = await fetch(`${BASE_URL}/character/${encodeURIComponent(name)}/${encodeURIComponent(realm)}/summary`);
-  if (!res.ok) {
-    throw new Error(`Warmane API error: ${res.status}`);
+  const cacheFile = characterCachePath(name, realm);
+  const cached = await readCache(cacheFile, 60 * 60 * 1000);
+  if (cached && cached.name === name && cached.realm === realm) {
+    return cached;
   }
-  return res.json();
+
+  await rateLimit();
+  const res = await fetch(
+    `${BASE_URL}/character/${encodeURIComponent(name)}/${encodeURIComponent(realm)}/summary`
+  );
+  if (res.status === 503) {
+    const err: any = new Error('Warmane API maintenance');
+    err.status = 503;
+    throw err;
+  }
+  if (!res.ok) {
+    const err: any = new Error(`Warmane API error: ${res.status}`);
+    err.status = res.status;
+    throw err;
+  }
+  const json = await res.json();
+  const toCache = { ...json, name, realm };
+  await writeCache(cacheFile, toCache);
+  return toCache;
 }
 
 export async function fetchGuildSummary(name: string, realm: string) {
@@ -94,9 +151,15 @@ export async function fetchGuildSummary(name: string, realm: string) {
     return cached;
   }
 
+  await rateLimit();
   const res = await fetch(
     `${BASE_URL}/guild/${encodeGuildName(name)}/${encodeURIComponent(realm)}/summary`
   );
+  if (res.status === 503) {
+    const err: any = new Error('Warmane API maintenance');
+    err.status = 503;
+    throw err;
+  }
   if (!res.ok) {
     const err: any = new Error(`Warmane API error: ${res.status}`);
     err.status = res.status;


### PR DESCRIPTION
## Summary
- cache character summaries just like guild summaries
- add token bucket rate limiting to Warmane API requests
- handle API maintenance and fallbacks for commands using `fetchCharacterSummary`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687e767d0e8483248ce6caa0633205a2