### PR TITLE
Optimize roster syncing and add manual sync command

### DIFF
--- a/src/commands/roster.ts
+++ b/src/commands/roster.ts
@@ -3,6 +3,7 @@ import { SupabaseClient } from '@supabase/supabase-js';
 import { Command } from '../types';
 import { requireGuildConfig } from '../utils/guild-config';
 import { fetchGuildMembers } from '../utils/warmane-api';
+import { handleApiError } from '../utils/api-error-handler';
 
 const command: Command = {
   data: new SlashCommandBuilder()
@@ -27,7 +28,8 @@ const command: Command = {
 
       await interaction.reply({ embeds: [embed], ephemeral: true });
     } catch (err) {
-      await interaction.reply({ content: 'Failed to fetch roster.', ephemeral: true });
+      const msg = handleApiError(err as any);
+      await interaction.reply({ content: msg, ephemeral: true });
     }
   }
 };

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,0 +1,41 @@
+import { SlashCommandBuilder, ChatInputCommandInteraction, GuildMember } from 'discord.js';
+import { SupabaseClient } from '@supabase/supabase-js';
+import { Command } from '../types';
+import { requireGuildConfig } from '../utils/guild-config';
+import { clearRosterCache } from '../utils/warmane-api';
+import { syncGuildRoles } from '../utils/role-sync';
+
+const cooldowns = new Map<string, number>();
+
+const command: Command = {
+  data: new SlashCommandBuilder()
+    .setName('sync')
+    .setDescription('Force roster refresh and role sync'),
+  async execute(interaction: ChatInputCommandInteraction, _supabase: SupabaseClient) {
+    const config = await requireGuildConfig(interaction);
+    if (!config) return;
+
+    const member = interaction.member as GuildMember;
+    const officerRole = config.officer_role_id;
+    if (!officerRole || !member.roles.cache.has(officerRole)) {
+      await interaction.reply({ content: 'Missing permission.', ephemeral: true });
+      return;
+    }
+
+    const last = cooldowns.get(interaction.guildId!);
+    if (last && Date.now() - last < 5 * 60 * 1000) {
+      await interaction.reply({ content: 'Sync recently performed. Try again later.', ephemeral: true });
+      return;
+    }
+
+    cooldowns.set(interaction.guildId!, Date.now());
+    await interaction.reply({ content: 'Refreshing roster and syncing roles...', ephemeral: true });
+
+    await clearRosterCache(config.warmane_guild_name, config.warmane_realm);
+    await syncGuildRoles(interaction.client, interaction.guildId!, true);
+
+    await interaction.followUp({ content: 'Sync complete.', ephemeral: true });
+  }
+};
+
+export default command;

--- a/src/utils/api-error-handler.ts
+++ b/src/utils/api-error-handler.ts
@@ -1,0 +1,10 @@
+export function handleApiError(err: any, nextSync?: Date): string {
+  if (!err) return 'Unknown error.';
+  if (err.status === 503) {
+    console.warn('[WarmaneAPI] Service unavailable');
+    const when = nextSync ? ` Next sync at ${nextSync.toLocaleTimeString()}.` : '';
+    return `Warmane Armory is down for maintenance.${when}`;
+  }
+  console.error('[WarmaneAPI] API error:', err);
+  return 'Failed to contact Warmane API. Please try again later.';
+}

--- a/src/utils/role-sync.ts
+++ b/src/utils/role-sync.ts
@@ -113,7 +113,7 @@ export async function syncUserRoles(member: GuildMember): Promise<void> {
 
 export async function syncMemberRoles(
   member: GuildMember,
-  roster?: any
+  roster: any
 ) {
   try {
     if (
@@ -130,13 +130,8 @@ export async function syncMemberRoles(
       return;
     }
 
-    const guildName = config.warmane_guild_name;
-    const realm = config.warmane_realm;
     const memberRoleId = config.member_role_id;
-
-    const data = roster ?? (await fetchGuildMembers(guildName, realm));
-    console.log('[RoleSync] Warmane roster response:', JSON.stringify(data));
-    const members = data.members ?? data.roster ?? [];
+    const members = roster.members ?? roster.roster ?? [];
 
     const { data: rows } = await supabase
       .from('players')
@@ -188,7 +183,8 @@ export const syncTimers = new Map<string, NodeJS.Timeout>();
 
 export async function syncGuildRoles(
   client: Client,
-  guildId: string
+  guildId: string,
+  forceRosterRefresh = false
 ) {
   try {
     if (isSyncing) {
@@ -211,7 +207,7 @@ export async function syncGuildRoles(
     const guildName = config.warmane_guild_name;
     const realm = config.warmane_realm;
 
-    const roster = await fetchGuildMembers(guildName, realm);
+    const roster = await fetchGuildMembers(guildName, realm, forceRosterRefresh);
     console.log('[RoleSync] Full roster fetched:', JSON.stringify(roster));
     for (const [, member] of guild.members.cache) {
       await syncMemberRoles(member, roster);


### PR DESCRIPTION
## Summary
- queue Warmane API requests with adjustable delay
- support forced roster refresh and shorter cache times
- add global API error handler
- provide `/sync` command for officers
- use new error handler in `roster` command
- require roster param for member sync

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687e78a7a63c832496998eaaab45e173