### PR TITLE
Fix interaction error handling

### DIFF
--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -31,9 +31,6 @@ const command: Command = {
       return;
     }
 
-    const config = await requireGuildConfig(interaction);
-    if (!config) return;
-
     const modal = new ModalBuilder()
       .setCustomId('register_modal')
       .setTitle('Register Character')
@@ -57,6 +54,12 @@ const command: Command = {
       });
 
       await submit.deferReply({ ephemeral: true });
+
+      const config = await requireGuildConfig(interaction);
+      if (!config) {
+        await submit.editReply({ content: 'This server needs to be configured. An admin should run /setup' });
+        return;
+      }
 
       const name = submit.fields.getTextInputValue('character_name').trim();
       const realm = config.warmane_realm;

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -20,8 +20,12 @@ export default function registerInteractionCreate(client: Client, commands: Map<
         await command.execute(interaction, supabase);
       } catch (err) {
         logError(err);
-        if (!interaction.replied) {
-          await interaction.reply({ content: 'An error occurred.', ephemeral: true });
+        if (interaction.isRepliable() && !interaction.replied && !interaction.deferred) {
+          try {
+            await interaction.reply({ content: 'An error occurred.', ephemeral: true });
+          } catch (e) {
+            logError(e);
+          }
         }
       }
     } else if (interaction.isModalSubmit()) {


### PR DESCRIPTION
## Summary
- prevent duplicate replies when commands throw after responding
- show register modal before checking guild config to avoid Discord timeout

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687e7ed2a4988324a95368ccf1e4fa3b