### PR TITLE
Refactor register modal handling

### DIFF
--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -5,7 +5,7 @@ import {
   TextInputBuilder,
   TextInputStyle,
   ActionRowBuilder,
-  MessageFlags,
+  ModalSubmitInteraction,
 } from 'discord.js';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { Command } from '../types';
@@ -25,7 +25,7 @@ const command: Command = {
     .setName('register')
     .setDescription('Register a character'),
 
-  async execute(interaction: ChatInputCommandInteraction, supabase: SupabaseClient) {
+  async execute(interaction: ChatInputCommandInteraction, _supabase: SupabaseClient) {
     if (!interaction.guildId) {
       await interaction.reply({ content: 'This command can only be used in a server.', ephemeral: true });
       return;
@@ -46,95 +46,91 @@ const command: Command = {
       );
 
     await interaction.showModal(modal);
-
-    try {
-      const submit = await interaction.awaitModalSubmit({
-        filter: (i) => i.customId === 'register_modal' && i.user.id === interaction.user.id,
-        time: 60_000,
-      });
-
-      await submit.deferReply({ ephemeral: true });
-
-      const config = await requireGuildConfig(interaction);
-      if (!config) {
-        await submit.editReply({ content: 'This server needs to be configured. An admin should run /setup' });
-        return;
-      }
-
-      const name = submit.fields.getTextInputValue('character_name').trim();
-      const realm = config.warmane_realm;
-
-      try {
-        let summary;
-        let existingGs: number | null = null;
-        try {
-          summary = await fetchCharacterSummary(name, realm);
-          if (summary.error) {
-            await submit.editReply({ content: `Warmane API error: ${summary.error}` });
-            return;
-          }
-        } catch (err: any) {
-          if (err.status === 503) {
-            await submit.editReply({
-              content:
-                'Warmane API is currently under maintenance. Please try again later.',
-            });
-            return;
-          }
-          const { data: existing } = await supabase
-            .from('players')
-            .select('class, gear_score')
-            .eq('guild_id', interaction.guildId || '')
-            .eq('character_name', name)
-            .maybeSingle();
-          if (existing) {
-            summary = { name, class: existing.class, equipment: [] } as any;
-            existingGs = existing.gear_score;
-          } else {
-            throw err;
-          }
-        }
-
-        const rosterData = await fetchGuildMembers(config.warmane_guild_name, realm);
-        const members = rosterData.members ?? rosterData.roster ?? [];
-        const inGuild = members.some((m: any) => normalize(m.name) === normalize(name));
-        if (!inGuild) {
-          await submit.editReply({
-            content: `Character ${name} is not in ${config.warmane_guild_name}. Only guild members can register their characters.`
-          });
-          return;
-        }
-
-        console.log('Warmane equipment data:', summary.equipment);
-        const gearScore = summary.equipment && summary.equipment.length > 0
-          ? calculateGearScore(summary.equipment, summary.class)
-          : existingGs ?? 0;
-        const { error } = await supabase.from('players').insert({
-          guild_id: interaction.guildId,
-          discord_id: interaction.user.id,
-          character_name: name,
-          realm,
-          class: summary.class,
-          gear_score: gearScore,
-          last_updated: new Date().toISOString(),
-        });
-        if (error) {
-          await submit.editReply({ content: `Database error: ${error.message}` });
-          return;
-        }
-
-        const armoryUrl = `https://armory.warmane.com/character/${encodeURIComponent(name)}/${encodeURIComponent(realm)}`;
-        await submit.editReply({
-          content: `Registered **[${summary.name}](${armoryUrl})** on ${realm}! GearScore: **${gearScore}**`,
-        });
-      } catch (err) {
-        console.error('Register character error:', err);
-        await submit.editReply({ content: 'Failed to register character.' });
-      }
-    } catch {
-      await interaction.followUp({ content: 'Registration timed out.', ephemeral: true, flags: MessageFlags.Ephemeral });
-    }
+    return;
   },
 };
 
 export default command;
+
+export async function handleRegisterModal(
+  interaction: ModalSubmitInteraction,
+  supabase: SupabaseClient
+) {
+  await interaction.deferReply({ ephemeral: true });
+
+  const config = await requireGuildConfig(interaction);
+  if (!config) {
+    await interaction.editReply({ content: 'This server needs to be configured. An admin should run /setup' });
+    return;
+  }
+
+  const name = interaction.fields.getTextInputValue('character_name').trim();
+  const realm = config.warmane_realm;
+
+  try {
+    let summary;
+    let existingGs: number | null = null;
+    try {
+      summary = await fetchCharacterSummary(name, realm);
+      if (summary.error) {
+        await interaction.editReply({ content: `Warmane API error: ${summary.error}` });
+        return;
+      }
+    } catch (err: any) {
+      if (err.status === 503) {
+        await interaction.editReply({
+          content: 'Warmane API is currently under maintenance. Please try again later.',
+        });
+        return;
+      }
+      const { data: existing } = await supabase
+        .from('players')
+        .select('class, gear_score')
+        .eq('guild_id', interaction.guildId || '')
+        .eq('character_name', name)
+        .maybeSingle();
+      if (existing) {
+        summary = { name, class: existing.class, equipment: [] } as any;
+        existingGs = existing.gear_score;
+      } else {
+        throw err;
+      }
+    }
+
+    const rosterData = await fetchGuildMembers(config.warmane_guild_name, realm);
+    const members = rosterData.members ?? rosterData.roster ?? [];
+    const inGuild = members.some((m: any) => normalize(m.name) === normalize(name));
+    if (!inGuild) {
+      await interaction.editReply({
+        content: `Character ${name} is not in ${config.warmane_guild_name}. Only guild members can register their characters.`
+      });
+      return;
+    }
+
+    console.log('Warmane equipment data:', summary.equipment);
+    const gearScore = summary.equipment && summary.equipment.length > 0
+      ? calculateGearScore(summary.equipment, summary.class)
+      : existingGs ?? 0;
+    const { error } = await supabase.from('players').insert({
+      guild_id: interaction.guildId,
+      discord_id: interaction.user.id,
+      character_name: name,
+      realm,
+      class: summary.class,
+      gear_score: gearScore,
+      last_updated: new Date().toISOString(),
+    });
+    if (error) {
+      await interaction.editReply({ content: `Database error: ${error.message}` });
+      return;
+    }
+
+    const armoryUrl = `https://armory.warmane.com/character/${encodeURIComponent(name)}/${encodeURIComponent(realm)}`;
+    await interaction.editReply({
+      content: `Registered **[${summary.name}](${armoryUrl})** on ${realm}! GearScore: **${gearScore}**`,
+    });
+  } catch (err) {
+    console.error('Register character error:', err);
+    await interaction.editReply({ content: 'Failed to register character.' });
+  }
+}

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -2,6 +2,7 @@ import { Client, Events } from 'discord.js';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { Command } from '../types';
 import { handleRaidCreateModal, handleRaidInstanceSelect } from '../commands/raid';
+import { handleRegisterModal } from '../commands/register';
 import {
   handleRaidSignupButton,
   handleRaidLeaveButton,
@@ -31,6 +32,8 @@ export default function registerInteractionCreate(client: Client, commands: Map<
     } else if (interaction.isModalSubmit()) {
       if (interaction.customId.startsWith('raid-create-modal')) {
         await handleRaidCreateModal(interaction, supabase);
+      } else if (interaction.customId === 'register_modal') {
+        await handleRegisterModal(interaction, supabase);
       }
     } else if (interaction.isButton()) {
       if (interaction.customId.startsWith('raid-signup:')) {

--- a/src/utils/guild-config.ts
+++ b/src/utils/guild-config.ts
@@ -1,4 +1,4 @@
-import { ChatInputCommandInteraction } from 'discord.js';
+import { RepliableInteraction } from 'discord.js';
 import supabase from '../config/database';
 import { GuildConfig } from '../types';
 
@@ -32,7 +32,7 @@ export async function getGuildConfig(
 }
 
 export async function requireGuildConfig(
-  interaction: ChatInputCommandInteraction
+  interaction: RepliableInteraction
 ): Promise<GuildConfig | null> {
   const guildId = interaction.guildId ?? '';
   const config = await getGuildConfig(guildId);


### PR DESCRIPTION
## Summary
- avoid double acknowledgement by handling register modal in event listener
- add `handleRegisterModal` and adjust interactionCreate event
- allow `requireGuildConfig` to accept any repliable interaction

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687e90ca3a38832494e64ae393501352