### PR TITLE
Fix interaction timing

### DIFF
--- a/src/commands/admin.ts
+++ b/src/commands/admin.ts
@@ -12,12 +12,13 @@ const command: Command = {
     .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
   async execute(interaction: ChatInputCommandInteraction, supabase: SupabaseClient) {
     const sub = interaction.options.getSubcommand();
+    await interaction.deferReply({ ephemeral: true });
     if (sub === 'pingdb') {
       const { error } = await supabase.rpc('version');
       if (error) {
-        await interaction.reply({ content: `Database error: ${error.message}`, ephemeral: true });
+        await interaction.editReply({ content: `Database error: ${error.message}` });
       } else {
-        await interaction.reply({ content: 'Database connection OK.', ephemeral: true });
+        await interaction.editReply({ content: 'Database connection OK.' });
       }
     }
   }

--- a/src/commands/raid.ts
+++ b/src/commands/raid.ts
@@ -151,11 +151,13 @@ const command: Command = {
     const config = await requireGuildConfig(interaction);
     if (!config) return;
 
+    await interaction.deferReply({ ephemeral: true });
+
     if (sub === 'create') {
       const member = interaction.member as GuildMember;
       const officerRoleId = config.officer_role_id || '';
       if (!officerRoleId || !member?.roles?.cache?.has(officerRoleId)) {
-        await interaction.reply({ content: 'Missing permission.', ephemeral: true });
+        await interaction.editReply({ content: 'Missing permission.' });
         return;
       }
 
@@ -181,7 +183,7 @@ const command: Command = {
         }
       }
       const row = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu);
-      await interaction.reply({ content: 'Choose raid instance:', components: [row], ephemeral: true });
+      await interaction.editReply({ content: 'Choose raid instance:', components: [row] });
     } else if (sub === 'list') {
       const now = new Date().toISOString();
       const { data: raids } = await supabase
@@ -191,7 +193,7 @@ const command: Command = {
         .order('scheduled_date', { ascending: true });
 
       if (!raids || raids.length === 0) {
-        await interaction.reply({ content: 'No raids scheduled.', ephemeral: true });
+        await interaction.editReply({ content: 'No raids scheduled.' });
         return;
       }
 
@@ -208,12 +210,12 @@ const command: Command = {
           value: `Date: ${raid.scheduled_date}\nSignups: ${count}/${total}\nID: ${raid.id}`,
         });
       }
-      await interaction.reply({ embeds: [embed], ephemeral: true });
+      await interaction.editReply({ embeds: [embed] });
     } else if (sub === 'cancel') {
       const member = interaction.member as GuildMember;
       const officerRoleId = config?.officer_role_id || '';
       if (!officerRoleId || !member?.roles?.cache?.has(officerRoleId)) {
-        await interaction.reply({ content: 'Missing permission.', ephemeral: true });
+        await interaction.editReply({ content: 'Missing permission.' });
         return;
       }
 
@@ -226,7 +228,7 @@ const command: Command = {
         .maybeSingle();
 
       if (!raid) {
-        await interaction.reply({ content: 'Raid not found.', ephemeral: true });
+        await interaction.editReply({ content: 'Raid not found.' });
         return;
       }
 
@@ -240,7 +242,7 @@ const command: Command = {
         } catch {}
       }
 
-      await interaction.reply({ content: 'Raid cancelled.', ephemeral: true });
+      await interaction.editReply({ content: 'Raid cancelled.' });
     }
   }
 };
@@ -313,10 +315,12 @@ export async function handleRaidCreateModal(
     return;
   }
 
+  await interaction.deferReply({ ephemeral: true });
+
   const [, raidValue] = interaction.customId.split(':');
   const option = RAID_OPTIONS.find((o) => o.value === raidValue);
   if (!option) {
-    await interaction.reply({ content: 'Invalid raid type.', ephemeral: true });
+    await interaction.editReply({ content: 'Invalid raid type.' });
     return;
   }
 
@@ -365,14 +369,14 @@ export async function handleRaidCreateModal(
   const embed = buildRaidEmbed(raid as Raid, [], config.warmane_realm, []);
   const channel = interaction.guild?.channels.cache.get(config.raid_channel_id) as TextChannel | undefined;
   if (!channel || channel.type !== ChannelType.GuildText) {
-    await interaction.reply({ content: 'Raid channel not found.', ephemeral: true });
+    await interaction.editReply({ content: 'Raid channel not found.' });
     return;
   }
   const msg = await channel.send({ embeds: [embed], components: [buttons] });
 
   await supabase.from('raids').update({ signup_message_id: msg.id }).eq('id', raid.id);
 
-  await interaction.reply({ content: 'Raid created.', ephemeral: true });
+  await interaction.editReply({ content: 'Raid created.' });
 }
 
 

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -69,6 +69,8 @@ const command: Command = {
 
     const sub = interaction.options.getSubcommand();
 
+    await interaction.deferReply({ ephemeral: true });
+
     if (sub === 'status') {
       const guildId = interaction.guild.id;
       const { data: config } = await supabase
@@ -78,9 +80,8 @@ const command: Command = {
         .maybeSingle();
 
       if (!config || !config.setup_complete) {
-        await interaction.reply({
-          content: 'Not configured. Run /setup to configure.',
-          ephemeral: true
+        await interaction.editReply({
+          content: 'Not configured. Run /setup to configure.'
         });
         return;
       }
@@ -95,7 +96,7 @@ const command: Command = {
           { name: 'Raid Channel ID', value: config.raid_channel_id ?? 'None', inline: true }
         );
 
-      await interaction.reply({ embeds: [embed], ephemeral: true });
+      await interaction.editReply({ embeds: [embed] });
       return;
     }
 
@@ -108,11 +109,11 @@ const command: Command = {
       .maybeSingle();
 
     if (existing && existing.setup_complete) {
-      await interaction.reply({ content: 'Setup already completed for this server.', ephemeral: true });
+      await interaction.editReply({ content: 'Setup already completed for this server.' });
       return;
     }
 
-    await interaction.reply({ content: 'Check your DMs to continue setup.', ephemeral: true });
+    await interaction.editReply({ content: 'Check your DMs to continue setup.' });
     const dm = await interaction.user.createDM();
 
     try {

--- a/src/commands/template.ts
+++ b/src/commands/template.ts
@@ -23,11 +23,13 @@ const command: Command = {
     const config = await requireGuildConfig(interaction);
     if (!config) return;
 
+    await interaction.deferReply({ ephemeral: true });
+
     const sub = interaction.options.getSubcommand();
     const member = interaction.member as GuildMember;
     const officerRoleId = config.officer_role_id || '';
     if (!officerRoleId || !member.roles.cache.has(officerRoleId)) {
-      await interaction.reply({ content: 'Missing permission.', ephemeral: true });
+      await interaction.editReply({ content: 'Missing permission.' });
       return;
     }
 
@@ -48,18 +50,18 @@ const command: Command = {
         dps_slots: dps,
         min_gearscore: minGs
       }, { onConflict: 'guild_id,name' });
-      await interaction.reply({ content: 'Template saved.', ephemeral: true });
+      await interaction.editReply({ content: 'Template saved.' });
     } else {
       const { data } = await supabase
         .from('raid_templates')
         .select('*')
         .eq('guild_id', interaction.guildId!);
       if (!data || data.length === 0) {
-        await interaction.reply({ content: 'No templates saved.', ephemeral: true });
+        await interaction.editReply({ content: 'No templates saved.' });
         return;
       }
       const list = data.map(t => `**${t.name}** - ${t.instance}`).join('\n');
-      await interaction.reply({ content: list, ephemeral: true });
+      await interaction.editReply({ content: list });
     }
   }
 };

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -21,12 +21,19 @@ export default function registerInteractionCreate(client: Client, commands: Map<
         await command.execute(interaction, supabase);
       } catch (err) {
         logError(err);
-        if (interaction.isRepliable() && !interaction.replied && !interaction.deferred) {
-          try {
-            await interaction.reply({ content: 'An error occurred.', ephemeral: true });
-          } catch (e) {
-            logError(e);
+        try {
+          if (interaction.replied || interaction.deferred) {
+            await interaction.editReply({
+              content: 'There was an error while executing this command!'
+            });
+          } else if (interaction.isRepliable()) {
+            await interaction.reply({
+              content: 'There was an error while executing this command!',
+              ephemeral: true,
+            });
           }
+        } catch (e) {
+          logError(e);
         }
       }
     } else if (interaction.isModalSubmit()) {

--- a/src/utils/button-handlers.ts
+++ b/src/utils/button-handlers.ts
@@ -19,6 +19,8 @@ export async function handleRaidSignupButton(
 ) {
   const [, raidId] = interaction.customId.split(':');
 
+  await interaction.deferReply({ ephemeral: true });
+
   try {
     const { menu } = await buildCharacterSelectMenu(
       supabase,
@@ -27,9 +29,9 @@ export async function handleRaidSignupButton(
       CHAR_SELECT_ID(raidId)
     );
     const row = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu);
-    await interaction.reply({ content: 'Choose your character:', components: [row], ephemeral: true });
+    await interaction.editReply({ content: 'Choose your character:', components: [row] });
   } catch {
-    await interaction.reply({ content: 'Register a character first.', ephemeral: true });
+    await interaction.editReply({ content: 'Register a character first.' });
   }
 }
 
@@ -40,9 +42,11 @@ export async function handleRaidRoleSelect(
   const [, raidId] = interaction.customId.split(':');
   const role = interaction.values[0] as 'tank' | 'healer' | 'dps';
 
+  await interaction.deferUpdate();
+
   const { data: raid } = await supabase.from('raids').select('*').eq('id', raidId).maybeSingle();
   if (!raid) {
-    await interaction.update({ content: 'Raid not found.', components: [] });
+    await interaction.editReply({ content: 'Raid not found.', components: [] });
     return;
   }
   try {
@@ -59,9 +63,9 @@ export async function handleRaidRoleSelect(
     }
 
     const row = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu);
-    await interaction.update({ content: 'Select character:', components: [row] });
+    await interaction.editReply({ content: 'Select character:', components: [row] });
   } catch {
-    await interaction.update({ content: 'Register a character first.', components: [] });
+    await interaction.editReply({ content: 'Register a character first.', components: [] });
   }
 }
 
@@ -101,7 +105,7 @@ async function signupCharacter(
   };
 
   if (charClass && !roleAllowed[role].includes(charClass)) {
-    await interaction.update({
+    await interaction.editReply({
       content: `${character} cannot sign as ${role}.`,
       components: []
     });
@@ -155,7 +159,7 @@ async function signupCharacter(
     } catch {}
   }
 
-  await interaction.update({ content: `Signed up as ${character} (${role})!`, components: [] });
+  await interaction.editReply({ content: `Signed up as ${character} (${role})!`, components: [] });
 }
 
 export async function handleRaidCharacterSelect(
@@ -165,9 +169,11 @@ export async function handleRaidCharacterSelect(
   const [, raidId] = interaction.customId.split(':');
   const character = interaction.values[0];
 
+  await interaction.deferUpdate();
+
   const { data: raid } = await supabase.from('raids').select('*').eq('id', raidId).maybeSingle();
   if (!raid) {
-    await interaction.update({ content: 'Raid not found.', components: [] });
+    await interaction.editReply({ content: 'Raid not found.', components: [] });
     return;
   }
 
@@ -180,9 +186,11 @@ export async function handleRaidLeaveButton(
 ) {
   const [, raidId] = interaction.customId.split(':');
 
+  await interaction.deferReply({ ephemeral: true });
+
   const { data: raid } = await supabase.from('raids').select('*').eq('id', raidId).maybeSingle();
   if (!raid) {
-    await interaction.reply({ content: 'Raid not found.', ephemeral: true });
+    await interaction.editReply({ content: 'Raid not found.' });
     return;
   }
 
@@ -194,7 +202,7 @@ export async function handleRaidLeaveButton(
 
   const characters = rows?.map(r => r.character_name) ?? [];
   if (characters.length === 0) {
-    await interaction.reply({ content: 'Register a character first.', ephemeral: true });
+    await interaction.editReply({ content: 'Register a character first.' });
     return;
   }
 
@@ -237,5 +245,5 @@ export async function handleRaidLeaveButton(
     } catch {}
   }
 
-  await interaction.reply({ content: 'You have left the raid.', ephemeral: true });
+  await interaction.editReply({ content: 'You have left the raid.' });
 }


### PR DESCRIPTION
## Summary
- ensure commands use `deferReply` before long tasks
- edit replies appropriately after deferring
- update interactionCreate handler to avoid double replies

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687e985e0da08324b593334ca3454f65