### PR TITLE
Fix ephemeral replies

### DIFF
--- a/src/commands/admin.ts
+++ b/src/commands/admin.ts
@@ -1,4 +1,4 @@
-import { SlashCommandBuilder, ChatInputCommandInteraction, PermissionFlagsBits } from 'discord.js';
+import { SlashCommandBuilder, ChatInputCommandInteraction, PermissionFlagsBits, MessageFlags } from 'discord.js';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { Command } from '../types';
 
@@ -12,7 +12,7 @@ const command: Command = {
     .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
   async execute(interaction: ChatInputCommandInteraction, supabase: SupabaseClient) {
     const sub = interaction.options.getSubcommand();
-    await interaction.deferReply({ ephemeral: true });
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
     if (sub === 'pingdb') {
       const { error } = await supabase.rpc('version');
       if (error) {

--- a/src/commands/bench.ts
+++ b/src/commands/bench.ts
@@ -1,4 +1,4 @@
-import { SlashCommandBuilder, ChatInputCommandInteraction, GuildMember } from 'discord.js';
+import { SlashCommandBuilder, ChatInputCommandInteraction, GuildMember, MessageFlags } from 'discord.js';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { Command } from '../types';
 import { requireGuildConfig } from '../utils/guild-config';
@@ -17,7 +17,7 @@ const command: Command = {
     const member = interaction.member as GuildMember;
     const officerRoleId = config.officer_role_id || '';
     if (!officerRoleId || !member.roles.cache.has(officerRoleId)) {
-      await interaction.reply({ content: 'Missing permission.', ephemeral: true });
+      await interaction.reply({ content: 'Missing permission.', flags: MessageFlags.Ephemeral });
       return;
     }
 
@@ -33,7 +33,7 @@ const command: Command = {
       .maybeSingle();
 
     if (!signup) {
-      await interaction.reply({ content: 'Signup not found.', ephemeral: true });
+      await interaction.reply({ content: 'Signup not found.', flags: MessageFlags.Ephemeral });
       return;
     }
 
@@ -42,7 +42,7 @@ const command: Command = {
       .update({ benched: !remove })
       .eq('id', signup.id);
 
-    await interaction.reply({ content: remove ? 'Removed from bench.' : 'Benched.', ephemeral: true });
+    await interaction.reply({ content: remove ? 'Removed from bench.' : 'Benched.', flags: MessageFlags.Ephemeral });
   }
 };
 

--- a/src/commands/gearscore.ts
+++ b/src/commands/gearscore.ts
@@ -5,7 +5,8 @@ import {
   ActionRowBuilder,
   StringSelectMenuBuilder,
   StringSelectMenuInteraction,
-  User
+  User,
+  MessageFlags
 } from 'discord.js';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { Command } from '../types';
@@ -94,7 +95,7 @@ const command: Command = {
       return;
     }
 
-    await interaction.deferReply({ ephemeral: true });
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
     const target = userOpt ?? interaction.user;
     try {
       const { menu, characters } = await buildCharacterSelectMenu(

--- a/src/commands/raid.ts
+++ b/src/commands/raid.ts
@@ -14,6 +14,7 @@ import {
   ChannelType,
   StringSelectMenuBuilder,
   StringSelectMenuInteraction,
+  MessageFlags,
 } from 'discord.js';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { Command, Raid } from '../types';
@@ -151,7 +152,7 @@ const command: Command = {
     const config = await requireGuildConfig(interaction);
     if (!config) return;
 
-    await interaction.deferReply({ ephemeral: true });
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
     if (sub === 'create') {
       const member = interaction.member as GuildMember;
@@ -270,7 +271,7 @@ export async function handleRaidInstanceSelect(
   }
 
   if (!option) {
-    await interaction.reply({ content: 'Invalid raid selection.', ephemeral: true });
+    await interaction.reply({ content: 'Invalid raid selection.', flags: MessageFlags.Ephemeral });
     return;
   }
 
@@ -311,11 +312,11 @@ export async function handleRaidCreateModal(
 ) {
   const config = await getGuildConfig(interaction.guildId ?? '');
   if (!config || !config.raid_channel_id) {
-    await interaction.reply({ content: 'Guild is not fully configured.', ephemeral: true });
+    await interaction.reply({ content: 'Guild is not fully configured.', flags: MessageFlags.Ephemeral });
     return;
   }
 
-  await interaction.deferReply({ ephemeral: true });
+  await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
   const [, raidValue] = interaction.customId.split(':');
   const option = RAID_OPTIONS.find((o) => o.value === raidValue);

--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -28,7 +28,7 @@ const command: Command = {
 
   async execute(interaction: ChatInputCommandInteraction, _supabase: SupabaseClient) {
     if (!interaction.guildId) {
-      await interaction.reply({ content: 'This command can only be used in a server.', ephemeral: true });
+      await interaction.reply({ content: 'This command can only be used in a server.', flags: MessageFlags.Ephemeral });
       return;
     }
 

--- a/src/commands/roster.ts
+++ b/src/commands/roster.ts
@@ -1,4 +1,4 @@
-import { SlashCommandBuilder, ChatInputCommandInteraction, EmbedBuilder } from 'discord.js';
+import { SlashCommandBuilder, ChatInputCommandInteraction, EmbedBuilder, MessageFlags } from 'discord.js';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { Command } from '../types';
 import { requireGuildConfig } from '../utils/guild-config';
@@ -26,10 +26,10 @@ const command: Command = {
           { name: `Offline (${offline.length})`, value: offline.slice(0, 20).join(', ') || 'None' }
         );
 
-      await interaction.reply({ embeds: [embed], ephemeral: true });
+      await interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral });
     } catch (err) {
       const msg = handleApiError(err as any);
-      await interaction.reply({ content: msg, ephemeral: true });
+      await interaction.reply({ content: msg, flags: MessageFlags.Ephemeral });
     }
   }
 };

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -7,6 +7,7 @@ import {
   ActionRowBuilder,
   StringSelectMenuBuilder,
   ComponentType,
+  MessageFlags,
 } from 'discord.js';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { Command } from '../types';
@@ -63,13 +64,13 @@ const command: Command = {
     ),
   async execute(interaction: ChatInputCommandInteraction, supabase: SupabaseClient) {
     if (!interaction.guild) {
-      await interaction.reply({ content: 'This command can only be used in a server.', ephemeral: true });
+      await interaction.reply({ content: 'This command can only be used in a server.', flags: MessageFlags.Ephemeral });
       return;
     }
 
     const sub = interaction.options.getSubcommand();
 
-    await interaction.deferReply({ ephemeral: true });
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
     if (sub === 'status') {
       const guildId = interaction.guild.id;
@@ -215,7 +216,7 @@ const command: Command = {
         );
 
       await dm.send({ embeds: [embed] });
-      await interaction.followUp({ content: 'Setup complete!', ephemeral: true });
+      await interaction.followUp({ content: 'Setup complete!', flags: MessageFlags.Ephemeral });
     } catch {
       await dm.send('Setup aborted.');
     }

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,4 +1,4 @@
-import { SlashCommandBuilder, ChatInputCommandInteraction, GuildMember } from 'discord.js';
+import { SlashCommandBuilder, ChatInputCommandInteraction, GuildMember, MessageFlags } from 'discord.js';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { Command } from '../types';
 import { requireGuildConfig } from '../utils/guild-config';
@@ -18,23 +18,23 @@ const command: Command = {
     const member = interaction.member as GuildMember;
     const officerRole = config.officer_role_id;
     if (!officerRole || !member.roles.cache.has(officerRole)) {
-      await interaction.reply({ content: 'Missing permission.', ephemeral: true });
+      await interaction.reply({ content: 'Missing permission.', flags: MessageFlags.Ephemeral });
       return;
     }
 
     const last = cooldowns.get(interaction.guildId!);
     if (last && Date.now() - last < 5 * 60 * 1000) {
-      await interaction.reply({ content: 'Sync recently performed. Try again later.', ephemeral: true });
+      await interaction.reply({ content: 'Sync recently performed. Try again later.', flags: MessageFlags.Ephemeral });
       return;
     }
 
     cooldowns.set(interaction.guildId!, Date.now());
-    await interaction.reply({ content: 'Refreshing roster and syncing roles...', ephemeral: true });
+    await interaction.reply({ content: 'Refreshing roster and syncing roles...', flags: MessageFlags.Ephemeral });
 
     await clearRosterCache(config.warmane_guild_name, config.warmane_realm);
     await syncGuildRoles(interaction.client, interaction.guildId!, true);
 
-    await interaction.followUp({ content: 'Sync complete.', ephemeral: true });
+    await interaction.followUp({ content: 'Sync complete.', flags: MessageFlags.Ephemeral });
   }
 };
 

--- a/src/commands/template.ts
+++ b/src/commands/template.ts
@@ -1,4 +1,4 @@
-import { SlashCommandBuilder, ChatInputCommandInteraction, GuildMember } from 'discord.js';
+import { SlashCommandBuilder, ChatInputCommandInteraction, GuildMember, MessageFlags } from 'discord.js';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { Command } from '../types';
 import { requireGuildConfig } from '../utils/guild-config';
@@ -23,7 +23,7 @@ const command: Command = {
     const config = await requireGuildConfig(interaction);
     if (!config) return;
 
-    await interaction.deferReply({ ephemeral: true });
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
     const sub = interaction.options.getSubcommand();
     const member = interaction.member as GuildMember;

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,4 +1,4 @@
-import { Client, Events } from 'discord.js';
+import { Client, Events, MessageFlags, InteractionReplyOptions } from 'discord.js';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { Command } from '../types';
 import { handleRaidCreateModal, handleRaidInstanceSelect } from '../commands/raid';
@@ -21,9 +21,9 @@ export default function registerInteractionCreate(client: Client, commands: Map<
         await command.execute(interaction, supabase);
       } catch (err) {
         logError(err);
-        const errorMessage = {
+        const errorMessage: InteractionReplyOptions = {
           content: 'There was an error while executing this command!',
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         };
         try {
           if (interaction.replied || interaction.deferred) {

--- a/src/utils/button-handlers.ts
+++ b/src/utils/button-handlers.ts
@@ -4,6 +4,7 @@ import {
   StringSelectMenuBuilder,
   ActionRowBuilder,
   StringSelectMenuInteraction,
+  MessageFlags,
 } from 'discord.js';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { Raid, RaidSignup } from '../types';
@@ -19,7 +20,7 @@ export async function handleRaidSignupButton(
 ) {
   const [, raidId] = interaction.customId.split(':');
 
-  await interaction.deferReply({ ephemeral: true });
+  await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
   try {
     const { menu } = await buildCharacterSelectMenu(
@@ -186,7 +187,7 @@ export async function handleRaidLeaveButton(
 ) {
   const [, raidId] = interaction.customId.split(':');
 
-  await interaction.deferReply({ ephemeral: true });
+  await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
   const { data: raid } = await supabase.from('raids').select('*').eq('id', raidId).maybeSingle();
   if (!raid) {

--- a/src/utils/guild-config.ts
+++ b/src/utils/guild-config.ts
@@ -1,4 +1,4 @@
-import { RepliableInteraction } from 'discord.js';
+import { RepliableInteraction, MessageFlags } from 'discord.js';
 import supabase from '../config/database';
 import { GuildConfig } from '../types';
 
@@ -39,7 +39,7 @@ export async function requireGuildConfig(
   if (!config) {
     await interaction.reply({
       content: 'This server needs to be configured. An admin should run /setup',
-      ephemeral: true
+      flags: MessageFlags.Ephemeral
     });
     return null;
   }


### PR DESCRIPTION
## Summary
- switch ephemeral replies to `flags: MessageFlags.Ephemeral`
- import `MessageFlags` where needed
- use typed error message in interactionCreate event

## Testing
- `npm install --silent`
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_b_687ec0c907048324a53978dcc70626d6